### PR TITLE
Add KNN regression algorithm

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,6 +130,7 @@ where
                 Algorithm::ElasticNet(model) => model.predict(&x),
                 Algorithm::RandomForestRegressor(model) => model.predict(&x),
                 Algorithm::DecisionTreeRegressor(model) => model.predict(&x),
+                Algorithm::KNNRegressor(model) => model.predict(&x),
             }.expect(
                 "Error during inference. This is likely a bug in the AutoML library. Please open an issue on GitHub.",
             ) // FinalAlgorithm::Blending { .. } => self.predict_by_model(x, top_model), //self.predict_blended_model(x, algorithm),

--- a/src/settings/settings_struct.rs
+++ b/src/settings/settings_struct.rs
@@ -57,8 +57,6 @@ where
     pub(crate) preprocessing: PreProcessing,
     /// Optional settings for linear regression
     pub(crate) linear_settings: Option<LinearRegressionParameters>,
-    // /// Optional settings for support vector regressor
-    // pub(crate) svr_settings: Option<SVRParameters>,
     /// Optional settings for lasso regression
     pub(crate) lasso_settings: Option<LassoParameters>,
     /// Optional settings for ridge regression
@@ -105,13 +103,13 @@ where
                 Algorithm::default_elastic_net(),
                 Algorithm::default_decision_tree(),
                 Algorithm::default_random_forest(),
+                Algorithm::default_knn_regressor(),
             ],
             preprocessing: PreProcessing::None,
             number_of_folds: 10,
             shuffle: false,
             verbose: false,
             linear_settings: None,
-            // svr_settings: None,
             lasso_settings: None,
             ridge_settings: None,
             elastic_net_settings: None,
@@ -169,7 +167,6 @@ where
             shuffle: false,
             verbose: false,
             linear_settings: Some(LinearRegressionParameters::default()),
-            // svr_settings: Some(SVRParameters::default()),
             lasso_settings: Some(LassoParameters::default()),
             ridge_settings: Some(RidgeRegressionParameters::default()),
             elastic_net_settings: Some(ElasticNetParameters::default()),

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -1,12 +1,19 @@
 #[path = "fixtures/regression_data.rs"]
 mod regression_data;
 
+use automl::settings::Algorithm;
 use automl::{DenseMatrix, Settings, SupervisedModel};
 use regression_data::regression_testing_data;
 
 #[test]
 fn test_default_regression() {
     let settings = Settings::default_regression();
+    test_from_settings(settings);
+}
+
+#[test]
+fn test_knn_only_regression() {
+    let settings = Settings::default_regression().only(Algorithm::default_knn_regressor());
     test_from_settings(settings);
 }
 


### PR DESCRIPTION
## Summary
- integrate KNNRegressor from smartcore into algorithm suite
- allow selecting KNN regression via settings and ensure predictions use it
- cover KNN-only run in regression tests

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo audit` *(fails: no such command)*

------
https://chatgpt.com/codex/tasks/task_e_68b46bb49f708325a4adc47d8066a9ef