### PR TITLE
refactor: use explicit settings imports in example

### DIFF
--- a/examples/print_settings.rs
+++ b/examples/print_settings.rs
@@ -1,4 +1,9 @@
-use automl::settings::*;
+use automl::settings::{
+    DecisionTreeRegressorParameters, Distance, ElasticNetParameters, KNNAlgorithmName,
+    KNNRegressorParameters, KNNWeightFunction, LassoParameters, LinearRegressionParameters,
+    LinearRegressionSolverName, Metric, PreProcessing, RandomForestRegressorParameters,
+    RidgeRegressionParameters, RidgeRegressionSolverName, Settings,
+};
 use smartcore::linalg::basic::matrix::DenseMatrix;
 
 fn main() {


### PR DESCRIPTION
## Summary
- avoid wildcard settings import in print_settings example

## Testing
- `cargo fmt`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo run --example print_settings`

------
https://chatgpt.com/codex/tasks/task_e_68b4b59bb8d88325bc42d08541ae4c9e