### PR TITLE
ci: enforce pedantic clippy and build docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,7 @@ jobs:
         with:
           components: rustfmt, clippy
       - name: Clippy
-        run: cargo clippy --all-targets -- -D warnings
-        continue-on-error: true
+        run: cargo clippy --all-targets -- -D warnings -D clippy::pedantic
 
   audit:
     runs-on: ubuntu-latest
@@ -67,6 +66,28 @@ jobs:
         run: cargo install cargo-audit
       - name: Audit
         run: cargo audit
+
+  doc:
+    runs-on: ubuntu-latest
+    needs: [fmt, clippy, audit]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libclang-dev libgtk-3-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev libssl-dev
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+      - name: Build docs
+        run: cargo doc --no-deps
+      - name: Test docs
+        run: cargo test --doc
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- run clippy without continue-on-error and enable pedantic lints
- add doc job to build rustdoc and run doc tests

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings -D clippy::pedantic` (fails: needless-pass-by-value, manual-let-else, must-use-candidate, doc-markdown, etc.)
- `cargo doc --no-deps`
- `cargo test --doc`
- `cargo test`
- `cargo audit`


------
https://chatgpt.com/codex/tasks/task_e_68b4b6b015688325ad1b81838d84b7ef