### PR TITLE
chore: pin dependency versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ keywords = ["machine-learning", "ml", "ai", "smartcore", "automl"]
 categories = ["algorithms", "mathematics", "science"]
 
 [dependencies]
-smartcore = { version = "^0.4", features = ["serde"] }
-serde = { version = "^1", features = ["derive"] }
-itertools = "^0.14"
-comfy-table = "^7"
-humantime = "^2"
+smartcore = { version = "=0.4.2", features = ["serde"] }
+serde = { version = "=1.0.219", features = ["derive"] }
+itertools = "=0.14.0"
+comfy-table = "=7.2.0"
+humantime = "=2.2.0"


### PR DESCRIPTION
## Summary
- lock smartcore, serde, itertools, comfy-table, and humantime to exact versions

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets`


------
https://chatgpt.com/codex/tasks/task_e_68b4c00e94608325b2a44d8d88865131