### PR TITLE
Add classification modeling support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ automl = { git = "https://github.com/cmccomb/rust-automl" }
 ```
 
 ```rust
-use automl::{Settings, SupervisedModel};
+use automl::{RegressionModel, Settings};
 use smartcore::linalg::basic::matrix::DenseMatrix;
 
 let x = DenseMatrix::from_2d_vec(&vec![
@@ -30,13 +30,14 @@ let x = DenseMatrix::from_2d_vec(&vec![
     vec![3.0, 4.0, 5.0],
 ]).unwrap();
 let y = vec![1.0_f64, 2.0, 3.0];
-let _model = SupervisedModel::new(x, y, Settings::default_regression());
+let _model = RegressionModel::new(x, y, Settings::default_regression());
 ```
 
 ## Examples
 ### Classification
 ```rust
-use automl::{Settings, SupervisedModel};
+use automl::{ClassificationModel};
+use automl::settings::ClassificationSettings;
 use smartcore::linalg::basic::matrix::DenseMatrix;
 
 let x = DenseMatrix::from_2d_vec(&vec![
@@ -45,8 +46,8 @@ let x = DenseMatrix::from_2d_vec(&vec![
     vec![1.0, 0.0],
     vec![0.0, 1.0],
 ]).unwrap();
-let y = vec![0.0_f64, 1.0, 1.0, 0.0];
-let _model = SupervisedModel::new(x, y, Settings::default_regression());
+let y = vec![0_i32, 1, 1, 0];
+let _model = ClassificationModel::new(x, y, ClassificationSettings::default());
 ```
 
 Model comparison:

--- a/examples/maximal_regression.rs
+++ b/examples/maximal_regression.rs
@@ -2,7 +2,7 @@
 //! Maximal regression example
 //!
 //! This example demonstrates the maximal steps required to run a model
-//! comparison using the `SupervisedModel` API. It loads a small regression
+//! comparison using the `RegressionModel` API. It loads a small regression
 //! fixture, builds default regression settings, trains all configured
 //! algorithms using cross-validation, and prints a comparison table.
 //!
@@ -16,12 +16,13 @@
 mod regression_data;
 
 use automl::{
-    DenseMatrix, Settings, SupervisedModel,
+    DenseMatrix, RegressionModel, Settings,
     settings::{
-        Algorithm, DecisionTreeRegressorParameters, Distance, ElasticNetParameters, FinalAlgorithm,
+        DecisionTreeRegressorParameters, Distance, ElasticNetParameters, FinalAlgorithm,
         KNNAlgorithmName, KNNRegressorParameters, KNNWeightFunction, LassoParameters,
         LinearRegressionParameters, LinearRegressionSolverName, Metric,
-        RandomForestRegressorParameters, RidgeRegressionParameters, RidgeRegressionSolverName,
+        RandomForestRegressorParameters, RegressionAlgorithm, RidgeRegressionParameters,
+        RidgeRegressionSolverName,
     },
 };
 use regression_data::regression_testing_data;
@@ -36,7 +37,7 @@ fn main() {
         .shuffle_data(true)
         .verbose(true)
         .with_final_model(FinalAlgorithm::Best)
-        .skip(Algorithm::default_random_forest())
+        .skip(RegressionAlgorithm::default_random_forest())
         .sorted_by(Metric::RSquared)
         // .with_preprocessing(PreProcessing::AddInteractions)
         .with_linear_settings(
@@ -93,7 +94,7 @@ fn main() {
         );
 
     // Load a dataset from smartcore and add it to the regressor along with the customized settings
-    let mut model = SupervisedModel::new(x, y, settings);
+    let mut model = RegressionModel::new(x, y, settings);
 
     // Run a model comparison with all models at default settings
     model.train();

--- a/examples/maximal_regression.rs
+++ b/examples/maximal_regression.rs
@@ -17,12 +17,12 @@ mod regression_data;
 
 use automl::{
     DenseMatrix, RegressionModel, Settings,
+    algorithms::RegressionAlgorithm,
     settings::{
         DecisionTreeRegressorParameters, Distance, ElasticNetParameters, FinalAlgorithm,
         KNNAlgorithmName, KNNRegressorParameters, KNNWeightFunction, LassoParameters,
         LinearRegressionParameters, LinearRegressionSolverName, Metric,
-        RandomForestRegressorParameters, RegressionAlgorithm, RidgeRegressionParameters,
-        RidgeRegressionSolverName,
+        RandomForestRegressorParameters, RidgeRegressionParameters, RidgeRegressionSolverName,
     },
 };
 use regression_data::regression_testing_data;

--- a/examples/minimal_regression.rs
+++ b/examples/minimal_regression.rs
@@ -2,7 +2,7 @@
 //! Minimal regression example
 //!
 //! This example demonstrates the minimal steps required to run a model
-//! comparison using the `SupervisedModel` API. It loads a small regression
+//! comparison using the `RegressionModel` API. It loads a small regression
 //! fixture, builds default regression settings, trains all configured
 //! algorithms using cross-validation, and prints a comparison table.
 //!
@@ -15,7 +15,7 @@
 #[path = "../tests/fixtures/regression_data.rs"]
 mod regression_data;
 
-use automl::{Settings, SupervisedModel};
+use automl::{RegressionModel, Settings};
 use regression_data::regression_testing_data;
 
 fn main() {
@@ -26,7 +26,7 @@ fn main() {
     let settings = Settings::default_regression();
 
     // Load a dataset from smartcore and add it to the regressor along with the customized settings
-    let mut model = SupervisedModel::new(x, y, settings);
+    let mut model = RegressionModel::new(x, y, settings);
 
     // Run a model comparison with all models at default settings
     model.train();

--- a/src/algorithms/classification.rs
+++ b/src/algorithms/classification.rs
@@ -4,8 +4,7 @@ use std::fmt::{Display, Formatter};
 use std::time::Instant;
 
 use crate::model::ComparisonEntry;
-
-use super::ClassificationSettings;
+use crate::settings::ClassificationSettings;
 use smartcore::api::SupervisedEstimator;
 use smartcore::linalg::basic::arrays::{Array1, Array2, MutArrayView1, MutArrayView2};
 use smartcore::linalg::traits::cholesky::CholeskyDecomposable;
@@ -199,6 +198,7 @@ where
     }
 
     /// Get a vector of all possible algorithms
+    #[must_use]
     pub fn all_algorithms(settings: &ClassificationSettings) -> Vec<Self> {
         let mut algorithms = vec![Self::default_decision_tree_classifier()];
         if settings.knn_classifier_settings.is_some() {

--- a/src/algorithms/mod.rs
+++ b/src/algorithms/mod.rs
@@ -1,0 +1,7 @@
+//! Algorithm enumerations and helpers for model training.
+
+pub mod regression;
+pub use regression::RegressionAlgorithm;
+
+pub mod classification;
+pub use classification::ClassificationAlgorithm;

--- a/src/algorithms/regression.rs
+++ b/src/algorithms/regression.rs
@@ -1,12 +1,11 @@
 //!
-//! RegressionAlgorithm definitions and helpers
+//! `RegressionAlgorithm` definitions and helpers
 
 use std::fmt::{Display, Formatter};
 use std::time::Instant;
 
 use crate::model::ComparisonEntry;
-
-use super::Settings;
+use crate::settings::Settings;
 use crate::utils::distance::Distance;
 use smartcore::api::SupervisedEstimator;
 use smartcore::linalg::basic::arrays::{Array1, Array2, MutArrayView1, MutArrayView2};
@@ -20,7 +19,7 @@ use smartcore::model_selection::CrossValidationResult;
 use smartcore::numbers::floatnum::FloatNumber;
 use smartcore::numbers::realnum::RealNumber;
 
-/// RegressionAlgorithm options
+/// `RegressionAlgorithm` options
 pub enum RegressionAlgorithm<INPUT, OUTPUT, InputArray, OutputArray>
 where
     INPUT: RealNumber + FloatNumber,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,10 @@ pub mod cookbook;
 
 pub mod utils;
 
+/// Algorithm enumerations and helpers.
+pub mod algorithms;
+pub use algorithms::{ClassificationAlgorithm, RegressionAlgorithm};
+
 /// Model definitions and implementations.
 pub mod model;
 pub use model::{ClassificationModel, RegressionModel};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,6 @@ pub mod utils;
 
 /// Model definitions and implementations.
 pub mod model;
-pub use model::SupervisedModel;
+pub use model::{ClassificationModel, RegressionModel};
 
 pub use smartcore::linalg::basic::matrix::DenseMatrix;

--- a/src/model/classification.rs
+++ b/src/model/classification.rs
@@ -1,7 +1,8 @@
 //! Implementation of classification model training and evaluation.
 
 use super::{comparison::ComparisonEntry, preprocessing::Preprocessor};
-use crate::settings::{ClassificationAlgorithm, ClassificationSettings, FinalAlgorithm, Metric};
+use crate::algorithms::ClassificationAlgorithm;
+use crate::settings::{ClassificationSettings, FinalAlgorithm, Metric};
 use smartcore::{
     linalg::{
         basic::arrays::{Array, Array1, Array2, MutArrayView1},

--- a/src/model/classification.rs
+++ b/src/model/classification.rs
@@ -1,6 +1,6 @@
 //! Implementation of classification model training and evaluation.
 
-use super::preprocessing::Preprocessor;
+use super::{comparison::ComparisonEntry, preprocessing::Preprocessor};
 use crate::settings::{ClassificationAlgorithm, ClassificationSettings, FinalAlgorithm, Metric};
 use smartcore::{
     linalg::{
@@ -10,13 +10,11 @@ use smartcore::{
             svd::SVDDecomposable,
         },
     },
-    model_selection::CrossValidationResult,
     numbers::{basenum::Number, floatnum::FloatNumber, realnum::RealNumber},
 };
 use std::{
     cmp::Ordering::Equal,
     fmt::{Display, Formatter},
-    time::Duration,
 };
 use {
     comfy_table::{
@@ -24,13 +22,6 @@ use {
     },
     humantime::format_duration,
 };
-
-/// Alias for entries in the model comparison table.
-type ComparisonEntry<INPUT, OUTPUT, InputArray, OutputArray> = (
-    CrossValidationResult,
-    ClassificationAlgorithm<INPUT, OUTPUT, InputArray, OutputArray>,
-    Duration,
-);
 
 /// Trains and compares classification models
 pub struct ClassificationModel<INPUT, OUTPUT, InputArray, OutputArray>
@@ -53,7 +44,8 @@ where
     /// The training labels.
     y_train: OutputArray,
     /// The results of the model comparison.
-    comparison: Vec<ComparisonEntry<INPUT, OUTPUT, InputArray, OutputArray>>,
+    comparison:
+        Vec<ComparisonEntry<ClassificationAlgorithm<INPUT, OUTPUT, InputArray, OutputArray>>>,
     /// Preprocessor responsible for feature engineering.
     preprocessor: Preprocessor<INPUT, InputArray>,
 }
@@ -81,7 +73,12 @@ where
             .preprocess(x, &self.settings.preprocessing);
         match self.settings.final_model_approach {
             FinalAlgorithm::None => panic!(""),
-            FinalAlgorithm::Best => match &self.comparison.first().expect("").1 {
+            FinalAlgorithm::Best => match &self
+                .comparison
+                .first()
+                .expect("")
+                .algorithm
+            {
                 ClassificationAlgorithm::DecisionTreeClassifier(model) => model.predict(&x),
                 ClassificationAlgorithm::KNNClassifier(model) => model.predict(&x),
             }
@@ -135,11 +132,9 @@ where
     /// Record a model in the comparison.
     fn record_trained_model(
         &mut self,
-        trained_model: (
-            CrossValidationResult,
+        trained_model: ComparisonEntry<
             ClassificationAlgorithm<INPUT, OUTPUT, InputArray, OutputArray>,
-            Duration,
-        ),
+        >,
     ) {
         self.comparison.push(trained_model);
         self.sort();
@@ -148,8 +143,9 @@ where
     /// Sort the models in the comparison by their mean test scores.
     fn sort(&mut self) {
         self.comparison.sort_by(|a, b| {
-            a.0.mean_test_score()
-                .partial_cmp(&b.0.mean_test_score())
+            a.result
+                .mean_test_score()
+                .partial_cmp(&b.result.mean_test_score())
                 .unwrap_or(Equal)
         });
         if matches!(self.settings.sort_by, Metric::RSquared | Metric::Accuracy) {
@@ -182,16 +178,19 @@ where
         ]);
         for model in &self.comparison {
             let mut row_vec = vec![];
-            row_vec.push(model.1.to_string());
-            row_vec.push(format_duration(model.2).to_string());
-            let decider =
-                f64::midpoint(model.0.mean_train_score(), model.0.mean_test_score()).abs();
+            row_vec.push(model.algorithm.to_string());
+            row_vec.push(format_duration(model.duration).to_string());
+            let decider = f64::midpoint(
+                model.result.mean_train_score(),
+                model.result.mean_test_score(),
+            )
+            .abs();
             if decider > 0.01 && decider < 1000.0 {
-                row_vec.push(format!("{:.2}", &model.0.mean_train_score()));
-                row_vec.push(format!("{:.2}", &model.0.mean_test_score()));
+                row_vec.push(format!("{:.2}", &model.result.mean_train_score()));
+                row_vec.push(format!("{:.2}", &model.result.mean_test_score()));
             } else {
-                row_vec.push(format!("{:.3e}", &model.0.mean_train_score()));
-                row_vec.push(format!("{:.3e}", &model.0.mean_test_score()));
+                row_vec.push(format!("{:.3e}", &model.result.mean_train_score()));
+                row_vec.push(format!("{:.3e}", &model.result.mean_test_score()));
             }
 
             table.add_row(row_vec);

--- a/src/model/classification.rs
+++ b/src/model/classification.rs
@@ -1,0 +1,202 @@
+//! Implementation of classification model training and evaluation.
+
+use super::preprocessing::Preprocessor;
+use crate::settings::{ClassificationAlgorithm, ClassificationSettings, FinalAlgorithm, Metric};
+use smartcore::{
+    linalg::{
+        basic::arrays::{Array, Array1, Array2, MutArrayView1},
+        traits::{
+            cholesky::CholeskyDecomposable, evd::EVDDecomposable, qr::QRDecomposable,
+            svd::SVDDecomposable,
+        },
+    },
+    model_selection::CrossValidationResult,
+    numbers::{basenum::Number, floatnum::FloatNumber, realnum::RealNumber},
+};
+use std::{
+    cmp::Ordering::Equal,
+    fmt::{Display, Formatter},
+    time::Duration,
+};
+use {
+    comfy_table::{
+        Attribute, Cell, Table, modifiers::UTF8_SOLID_INNER_BORDERS, presets::UTF8_FULL,
+    },
+    humantime::format_duration,
+};
+
+/// Alias for entries in the model comparison table.
+type ComparisonEntry<INPUT, OUTPUT, InputArray, OutputArray> = (
+    CrossValidationResult,
+    ClassificationAlgorithm<INPUT, OUTPUT, InputArray, OutputArray>,
+    Duration,
+);
+
+/// Trains and compares classification models
+pub struct ClassificationModel<INPUT, OUTPUT, InputArray, OutputArray>
+where
+    INPUT: RealNumber + FloatNumber,
+    OUTPUT: Number + Ord,
+    InputArray: Clone
+        + Array<INPUT, (usize, usize)>
+        + Array2<INPUT>
+        + EVDDecomposable<INPUT>
+        + SVDDecomposable<INPUT>
+        + CholeskyDecomposable<INPUT>
+        + QRDecomposable<INPUT>,
+    OutputArray: Clone + MutArrayView1<OUTPUT> + Array1<OUTPUT>,
+{
+    /// Settings for the model.
+    settings: ClassificationSettings,
+    /// The training data.
+    x_train: InputArray,
+    /// The training labels.
+    y_train: OutputArray,
+    /// The results of the model comparison.
+    comparison: Vec<ComparisonEntry<INPUT, OUTPUT, InputArray, OutputArray>>,
+    /// Preprocessor responsible for feature engineering.
+    preprocessor: Preprocessor<INPUT, InputArray>,
+}
+
+impl<INPUT, OUTPUT, InputArray, OutputArray>
+    ClassificationModel<INPUT, OUTPUT, InputArray, OutputArray>
+where
+    INPUT: RealNumber + FloatNumber,
+    OUTPUT: Number + Ord,
+    InputArray: Clone
+        + Array<INPUT, (usize, usize)>
+        + Array2<INPUT>
+        + EVDDecomposable<INPUT>
+        + SVDDecomposable<INPUT>
+        + CholeskyDecomposable<INPUT>
+        + QRDecomposable<INPUT>,
+    OutputArray: Clone + MutArrayView1<OUTPUT> + Array1<OUTPUT>,
+{
+    /// Predict values using the final model based on a vec.
+    /// # Panics
+    /// If the model has not been trained, this function will panic.
+    pub fn predict(self, x: InputArray) -> OutputArray {
+        let x = self
+            .preprocessor
+            .preprocess(x, &self.settings.preprocessing);
+        match self.settings.final_model_approach {
+            FinalAlgorithm::None => panic!(""),
+            FinalAlgorithm::Best => match &self.comparison.first().expect("").1 {
+                ClassificationAlgorithm::DecisionTreeClassifier(model) => model.predict(&x),
+                ClassificationAlgorithm::KNNClassifier(model) => model.predict(&x),
+            }
+            .expect(
+                "Error during inference. This is likely a bug in the AutoML library. Please open an issue on GitHub.",
+            ),
+        }
+    }
+
+    /// Runs a model comparison and trains a final model.
+    pub fn train(&mut self) {
+        // Train any necessary preprocessing
+        self.preprocessor
+            .train(&self.x_train.clone(), &self.settings.preprocessing);
+
+        // Iterate over variants in Algorithm
+        for alg in ClassificationAlgorithm::all_algorithms(&self.settings) {
+            self.record_trained_model(alg.cross_validate_model(
+                &self.x_train,
+                &self.y_train,
+                &self.settings,
+            ));
+        }
+    }
+}
+
+impl<INPUT, OUTPUT, InputArray, OutputArray>
+    ClassificationModel<INPUT, OUTPUT, InputArray, OutputArray>
+where
+    INPUT: RealNumber + FloatNumber,
+    OUTPUT: Number + Ord,
+    InputArray: SVDDecomposable<INPUT>
+        + EVDDecomposable<INPUT>
+        + Clone
+        + Array<INPUT, (usize, usize)>
+        + CholeskyDecomposable<INPUT>
+        + QRDecomposable<INPUT>,
+    OutputArray: Clone + MutArrayView1<OUTPUT> + Array1<OUTPUT>,
+{
+    /// Build a new classification model
+    pub fn new(x: InputArray, y: OutputArray, settings: ClassificationSettings) -> Self {
+        Self {
+            settings,
+            x_train: x,
+            y_train: y,
+            comparison: vec![],
+            preprocessor: Preprocessor::new(),
+        }
+    }
+
+    /// Record a model in the comparison.
+    fn record_trained_model(
+        &mut self,
+        trained_model: (
+            CrossValidationResult,
+            ClassificationAlgorithm<INPUT, OUTPUT, InputArray, OutputArray>,
+            Duration,
+        ),
+    ) {
+        self.comparison.push(trained_model);
+        self.sort();
+    }
+
+    /// Sort the models in the comparison by their mean test scores.
+    fn sort(&mut self) {
+        self.comparison.sort_by(|a, b| {
+            a.0.mean_test_score()
+                .partial_cmp(&b.0.mean_test_score())
+                .unwrap_or(Equal)
+        });
+        if matches!(self.settings.sort_by, Metric::RSquared | Metric::Accuracy) {
+            self.comparison.reverse();
+        }
+    }
+}
+
+impl<INPUT, OUTPUT, InputArray, OutputArray> Display
+    for ClassificationModel<INPUT, OUTPUT, InputArray, OutputArray>
+where
+    INPUT: RealNumber + FloatNumber,
+    OUTPUT: Number + Ord,
+    InputArray: SVDDecomposable<INPUT>
+        + EVDDecomposable<INPUT>
+        + Clone
+        + CholeskyDecomposable<INPUT>
+        + QRDecomposable<INPUT>,
+    OutputArray: Clone + MutArrayView1<OUTPUT> + Array1<OUTPUT>,
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let mut table = Table::new();
+        table.load_preset(UTF8_FULL);
+        table.apply_modifier(UTF8_SOLID_INNER_BORDERS);
+        table.set_header(vec![
+            Cell::new("Model").add_attribute(Attribute::Bold),
+            Cell::new("Time").add_attribute(Attribute::Bold),
+            Cell::new(format!("Training {}", self.settings.sort_by)).add_attribute(Attribute::Bold),
+            Cell::new(format!("Testing {}", self.settings.sort_by)).add_attribute(Attribute::Bold),
+        ]);
+        for model in &self.comparison {
+            let mut row_vec = vec![];
+            row_vec.push(model.1.to_string());
+            row_vec.push(format_duration(model.2).to_string());
+            let decider =
+                f64::midpoint(model.0.mean_train_score(), model.0.mean_test_score()).abs();
+            if decider > 0.01 && decider < 1000.0 {
+                row_vec.push(format!("{:.2}", &model.0.mean_train_score()));
+                row_vec.push(format!("{:.2}", &model.0.mean_test_score()));
+            } else {
+                row_vec.push(format!("{:.3e}", &model.0.mean_train_score()));
+                row_vec.push(format!("{:.3e}", &model.0.mean_test_score()));
+            }
+
+            table.add_row(row_vec);
+        }
+
+        write!(f, "{table}")
+    }
+}

--- a/src/model/comparison.rs
+++ b/src/model/comparison.rs
@@ -1,0 +1,15 @@
+//! Shared comparison entry structure for model evaluations.
+
+use smartcore::model_selection::CrossValidationResult;
+use std::time::Duration;
+
+/// Stores the outcome of training an algorithm during model comparison.
+#[derive(Debug, Clone)]
+pub struct ComparisonEntry<A> {
+    /// Cross-validation metrics for the trained algorithm.
+    pub result: CrossValidationResult,
+    /// The trained algorithm instance.
+    pub algorithm: A,
+    /// Duration taken to train and evaluate the algorithm.
+    pub duration: Duration,
+}

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1,6 +1,8 @@
 //! Types and implementations for machine learning models.
 
+pub mod classification;
 mod preprocessing;
-pub mod supervised;
+pub mod regression;
 
-pub use supervised::SupervisedModel;
+pub use classification::ClassificationModel;
+pub use regression::RegressionModel;

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1,8 +1,10 @@
 //! Types and implementations for machine learning models.
 
 pub mod classification;
+mod comparison;
 mod preprocessing;
 pub mod regression;
 
 pub use classification::ClassificationModel;
+pub use comparison::ComparisonEntry;
 pub use regression::RegressionModel;

--- a/src/model/regression.rs
+++ b/src/model/regression.rs
@@ -1,7 +1,7 @@
-//! Implementation of supervised model training and evaluation.
+//! Implementation of regression model training and evaluation.
 
 use super::preprocessing::Preprocessor;
-use crate::settings::{Algorithm, FinalAlgorithm, Metric, Settings};
+use crate::settings::{FinalAlgorithm, Metric, RegressionAlgorithm, Settings};
 use smartcore::{
     linalg::{
         basic::arrays::{Array, Array1, Array2, MutArrayView1},
@@ -28,12 +28,12 @@ use {
 /// Alias for entries in the model comparison table.
 type ComparisonEntry<INPUT, OUTPUT, InputArray, OutputArray> = (
     CrossValidationResult,
-    Algorithm<INPUT, OUTPUT, InputArray, OutputArray>,
+    RegressionAlgorithm<INPUT, OUTPUT, InputArray, OutputArray>,
     Duration,
 );
 
-/// Trains and compares supervised models
-pub struct SupervisedModel<INPUT, OUTPUT, InputArray, OutputArray>
+/// Trains and compares regression models
+pub struct RegressionModel<INPUT, OUTPUT, InputArray, OutputArray>
 where
     INPUT: RealNumber + FloatNumber,
     OUTPUT: FloatNumber,
@@ -60,7 +60,7 @@ where
     preprocessor: Preprocessor<INPUT, InputArray>,
 }
 
-impl<INPUT, OUTPUT, InputArray, OutputArray> SupervisedModel<INPUT, OUTPUT, InputArray, OutputArray>
+impl<INPUT, OUTPUT, InputArray, OutputArray> RegressionModel<INPUT, OUTPUT, InputArray, OutputArray>
 where
     INPUT: RealNumber + FloatNumber,
     OUTPUT: FloatNumber, // + Eq + Hash,
@@ -76,14 +76,14 @@ where
     /// Predict values using the final model based on a vec.
     /// ```
     /// # use smartcore::linalg::basic::matrix::DenseMatrix;
-    /// # use automl::{settings, SupervisedModel, Settings};
+    /// # use automl::{settings, RegressionModel, Settings};
     /// # let x = DenseMatrix::from_2d_vec(&vec![vec![1.0_f64; 6]; 16]).unwrap();
     /// # let y = vec![0.0_f64; 16];
-    /// # let mut model = SupervisedModel::new(
+    /// # let mut model = RegressionModel::new(
     /// #    x,
     /// #    y,
     /// #    Settings::default_regression()
-    /// #        .only(&settings::Algorithm::default_linear()),
+    /// #        .only(&settings::RegressionAlgorithm::default_linear()),
     /// # );
     /// # model.train();
     /// let X = DenseMatrix::from_2d_vec(&vec![vec![5.0; 6]; 5]).unwrap();
@@ -99,16 +99,16 @@ where
         match self.settings.final_model_approach {
             FinalAlgorithm::None => panic!(""),
             FinalAlgorithm::Best => match &self.comparison.first().expect("").1 {
-                Algorithm::Linear(model) => model.predict(&x),
-                Algorithm::Lasso(model) => model.predict(&x),
-                Algorithm::Ridge(model) => model.predict(&x),
-                Algorithm::ElasticNet(model) => model.predict(&x),
-                Algorithm::RandomForestRegressor(model) => model.predict(&x),
-                Algorithm::DecisionTreeRegressor(model) => model.predict(&x),
-                Algorithm::KNNRegressorHamming(model) => model.predict(&x),
-                Algorithm::KNNRegressorEuclidian(model) => model.predict(&x),
-                Algorithm::KNNRegressorManhattan(model) => model.predict(&x),
-                Algorithm::KNNRegressorMinkowski(model) => model.predict(&x),
+                RegressionAlgorithm::Linear(model) => model.predict(&x),
+                RegressionAlgorithm::Lasso(model) => model.predict(&x),
+                RegressionAlgorithm::Ridge(model) => model.predict(&x),
+                RegressionAlgorithm::ElasticNet(model) => model.predict(&x),
+                RegressionAlgorithm::RandomForestRegressor(model) => model.predict(&x),
+                RegressionAlgorithm::DecisionTreeRegressor(model) => model.predict(&x),
+                RegressionAlgorithm::KNNRegressorHamming(model) => model.predict(&x),
+                RegressionAlgorithm::KNNRegressorEuclidian(model) => model.predict(&x),
+                RegressionAlgorithm::KNNRegressorManhattan(model) => model.predict(&x),
+                RegressionAlgorithm::KNNRegressorMinkowski(model) => model.predict(&x),
             }
             .expect(
                 "Error during inference. This is likely a bug in the AutoML library. Please open an issue on GitHub.",
@@ -120,15 +120,15 @@ where
 
     /// Runs a model comparison and trains a final model.
     /// ```
-    /// # use automl::{settings, SupervisedModel, Settings};
+    /// # use automl::{settings, RegressionModel, Settings};
     /// # use smartcore::linalg::basic::matrix::DenseMatrix;
     /// # let x = DenseMatrix::from_2d_vec(&vec![vec![1.0_f64; 6]; 16]).unwrap();
     /// # let y = vec![0.0_f64; 16];
-    /// let mut model = SupervisedModel::new(
+    /// let mut model = RegressionModel::new(
     ///     x,
     ///     y,
     ///     Settings::default_regression()
-    /// #        .only(&settings::Algorithm::default_linear())
+    /// #        .only(&settings::RegressionAlgorithm::default_linear())
     /// );
     /// model.train();
     /// ```
@@ -137,8 +137,8 @@ where
         self.preprocessor
             .train(&self.x_train.clone(), &self.settings.preprocessing);
 
-        // Iterate over variants in Algorithm
-        for alg in Algorithm::all_algorithms(&self.settings) {
+        // Iterate over variants in RegressionAlgorithm
+        for alg in RegressionAlgorithm::all_algorithms(&self.settings) {
             if !self.settings.skiplist.contains(&alg) {
                 self.record_trained_model(alg.cross_validate_model(
                     &self.x_train,
@@ -159,7 +159,7 @@ where
     }
 }
 
-impl<INPUT, OUTPUT, InputArray, OutputArray> SupervisedModel<INPUT, OUTPUT, InputArray, OutputArray>
+impl<INPUT, OUTPUT, InputArray, OutputArray> RegressionModel<INPUT, OUTPUT, InputArray, OutputArray>
 where
     INPUT: RealNumber + FloatNumber,
     OUTPUT: FloatNumber, // + Eq + Hash,
@@ -206,7 +206,7 @@ where
         &mut self,
         trained_model: (
             CrossValidationResult,
-            Algorithm<INPUT, OUTPUT, InputArray, OutputArray>,
+            RegressionAlgorithm<INPUT, OUTPUT, InputArray, OutputArray>,
             Duration,
         ),
     ) {
@@ -228,7 +228,7 @@ where
 }
 
 impl<INPUT, OUTPUT, InputArray, OutputArray> Display
-    for SupervisedModel<INPUT, OUTPUT, InputArray, OutputArray>
+    for RegressionModel<INPUT, OUTPUT, InputArray, OutputArray>
 where
     INPUT: RealNumber + FloatNumber,
     OUTPUT: FloatNumber,

--- a/src/model/regression.rs
+++ b/src/model/regression.rs
@@ -1,7 +1,8 @@
 //! Implementation of regression model training and evaluation.
 
 use super::{comparison::ComparisonEntry, preprocessing::Preprocessor};
-use crate::settings::{FinalAlgorithm, Metric, RegressionAlgorithm, Settings};
+use crate::algorithms::RegressionAlgorithm;
+use crate::settings::{FinalAlgorithm, Metric, Settings};
 use smartcore::{
     linalg::{
         basic::arrays::{Array, Array1, Array2, MutArrayView1},
@@ -69,14 +70,14 @@ where
     /// Predict values using the final model based on a vec.
     /// ```
     /// # use smartcore::linalg::basic::matrix::DenseMatrix;
-    /// # use automl::{settings, RegressionModel, Settings};
+    /// # use automl::{algorithms, RegressionModel, Settings};
     /// # let x = DenseMatrix::from_2d_vec(&vec![vec![1.0_f64; 6]; 16]).unwrap();
     /// # let y = vec![0.0_f64; 16];
     /// # let mut model = RegressionModel::new(
     /// #    x,
     /// #    y,
     /// #    Settings::default_regression()
-    /// #        .only(&settings::RegressionAlgorithm::default_linear()),
+    /// #        .only(&algorithms::RegressionAlgorithm::default_linear()),
     /// # );
     /// # model.train();
     /// let X = DenseMatrix::from_2d_vec(&vec![vec![5.0; 6]; 5]).unwrap();
@@ -118,7 +119,7 @@ where
 
     /// Runs a model comparison and trains a final model.
     /// ```
-    /// # use automl::{settings, RegressionModel, Settings};
+    /// # use automl::{algorithms, RegressionModel, Settings};
     /// # use smartcore::linalg::basic::matrix::DenseMatrix;
     /// # let x = DenseMatrix::from_2d_vec(&vec![vec![1.0_f64; 6]; 16]).unwrap();
     /// # let y = vec![0.0_f64; 16];
@@ -126,7 +127,7 @@ where
     ///     x,
     ///     y,
     ///     Settings::default_regression()
-    /// #        .only(&settings::RegressionAlgorithm::default_linear())
+    /// #        .only(&algorithms::RegressionAlgorithm::default_linear())
     /// );
     /// model.train();
     /// ```

--- a/src/settings/classification_algorithms.rs
+++ b/src/settings/classification_algorithms.rs
@@ -1,0 +1,283 @@
+//! Classification algorithm definitions and helpers.
+
+use std::fmt::{Display, Formatter};
+use std::time::{Duration, Instant};
+
+use super::ClassificationSettings;
+use smartcore::api::SupervisedEstimator;
+use smartcore::linalg::basic::arrays::{Array1, Array2, MutArrayView1, MutArrayView2};
+use smartcore::linalg::traits::cholesky::CholeskyDecomposable;
+use smartcore::linalg::traits::qr::QRDecomposable;
+use smartcore::linalg::traits::svd::SVDDecomposable;
+use smartcore::metrics::distance::euclidian::Euclidian;
+use smartcore::model_selection::CrossValidationResult;
+use smartcore::numbers::basenum::Number;
+use smartcore::numbers::floatnum::FloatNumber;
+use smartcore::numbers::realnum::RealNumber;
+
+/// Supported classification algorithms.
+pub enum ClassificationAlgorithm<INPUT, OUTPUT, InputArray, OutputArray>
+where
+    INPUT: RealNumber + FloatNumber,
+    OUTPUT: Number + Ord,
+    InputArray: MutArrayView2<INPUT>
+        + Sized
+        + Clone
+        + Array2<INPUT>
+        + QRDecomposable<INPUT>
+        + SVDDecomposable<INPUT>
+        + CholeskyDecomposable<INPUT>,
+    OutputArray: MutArrayView1<OUTPUT> + Sized + Clone + Array1<OUTPUT>,
+{
+    /// Decision tree classifier
+    DecisionTreeClassifier(
+        smartcore::tree::decision_tree_classifier::DecisionTreeClassifier<
+            INPUT,
+            OUTPUT,
+            InputArray,
+            OutputArray,
+        >,
+    ),
+    /// K-nearest neighbours classifier with Euclidean distance
+    KNNClassifier(
+        smartcore::neighbors::knn_classifier::KNNClassifier<
+            INPUT,
+            OUTPUT,
+            InputArray,
+            OutputArray,
+            Euclidian<INPUT>,
+        >,
+    ),
+}
+
+impl<INPUT, OUTPUT, InputArray, OutputArray>
+    ClassificationAlgorithm<INPUT, OUTPUT, InputArray, OutputArray>
+where
+    INPUT: RealNumber + FloatNumber,
+    OUTPUT: Number + Ord,
+    InputArray: MutArrayView2<INPUT>
+        + Sized
+        + Clone
+        + Array2<INPUT>
+        + QRDecomposable<INPUT>
+        + SVDDecomposable<INPUT>
+        + CholeskyDecomposable<INPUT>,
+    OutputArray: MutArrayView1<OUTPUT> + Sized + Clone + Array1<OUTPUT>,
+{
+    /// Fit the model
+    pub(crate) fn fit(
+        self,
+        x: &InputArray,
+        y: &OutputArray,
+        settings: &ClassificationSettings,
+    ) -> Self {
+        match self {
+            Self::DecisionTreeClassifier(_) => Self::DecisionTreeClassifier(
+                smartcore::tree::decision_tree_classifier::DecisionTreeClassifier::fit(
+                    x,
+                    y,
+                    settings
+                        .decision_tree_classifier_settings
+                        .as_ref()
+                        .unwrap()
+                        .clone(),
+                )
+                .expect(
+                    "Error during training. This is likely a bug in the AutoML library. Please open an issue on GitHub.",
+                ),
+            ),
+            Self::KNNClassifier(_) => Self::KNNClassifier(
+                smartcore::neighbors::knn_classifier::KNNClassifier::fit(
+                    x,
+                    y,
+                    smartcore::neighbors::knn_classifier::KNNClassifierParameters::default()
+                        .with_k(settings.knn_classifier_settings.as_ref().unwrap().k)
+                        .with_algorithm(
+                            settings
+                                .knn_classifier_settings
+                                .as_ref()
+                                .unwrap()
+                                .algorithm
+                                .clone(),
+                        )
+                        .with_weight(
+                            settings
+                                .knn_classifier_settings
+                                .as_ref()
+                                .unwrap()
+                                .weight
+                                .clone(),
+                        )
+                        .with_distance(Euclidian::new()),
+                )
+                .expect(
+                    "Error during training. This is likely a bug in the AutoML library. Please open an issue on GitHub.",
+                ),
+            ),
+        }
+    }
+
+    fn cv(
+        self,
+        x: &InputArray,
+        y: &OutputArray,
+        settings: &ClassificationSettings,
+    ) -> (
+        CrossValidationResult,
+        ClassificationAlgorithm<INPUT, OUTPUT, InputArray, OutputArray>,
+    ) {
+        match self {
+            Self::DecisionTreeClassifier(_) => (
+                smartcore::model_selection::cross_validate(
+                    smartcore::tree::decision_tree_classifier::DecisionTreeClassifier::new(),
+                    x,
+                    y,
+                    settings
+                        .decision_tree_classifier_settings
+                        .as_ref()
+                        .unwrap()
+                        .clone(),
+                    &settings.get_kfolds(),
+                    &settings.get_metric::<OUTPUT, OutputArray>(),
+                )
+                .expect(
+                    "Error during cross-validation. This is likely a bug in the AutoML library",
+                ),
+                Self::default_decision_tree_classifier().fit(x, y, settings),
+            ),
+            Self::KNNClassifier(_) => (
+                smartcore::model_selection::cross_validate(
+                    smartcore::neighbors::knn_classifier::KNNClassifier::new(),
+                    x,
+                    y,
+                    smartcore::neighbors::knn_classifier::KNNClassifierParameters::default()
+                        .with_k(settings.knn_classifier_settings.as_ref().unwrap().k)
+                        .with_algorithm(
+                            settings
+                                .knn_classifier_settings
+                                .as_ref()
+                                .unwrap()
+                                .algorithm
+                                .clone(),
+                        )
+                        .with_weight(
+                            settings
+                                .knn_classifier_settings
+                                .as_ref()
+                                .unwrap()
+                                .weight
+                                .clone(),
+                        )
+                        .with_distance(Euclidian::new()),
+                    &settings.get_kfolds(),
+                    &settings.get_metric::<OUTPUT, OutputArray>(),
+                )
+                .expect(
+                    "Error during cross-validation. This is likely a bug in the AutoML library",
+                ),
+                Self::default_knn_classifier().fit(x, y, settings),
+            ),
+        }
+    }
+
+    pub(crate) fn cross_validate_model(
+        self,
+        x: &InputArray,
+        y: &OutputArray,
+        settings: &ClassificationSettings,
+    ) -> (
+        CrossValidationResult,
+        ClassificationAlgorithm<INPUT, OUTPUT, InputArray, OutputArray>,
+        Duration,
+    ) {
+        let start = Instant::now();
+        let results = self.cv(x, y, settings);
+        let end = Instant::now();
+        (results.0, results.1, end.duration_since(start))
+    }
+
+    /// Get a vector of all possible algorithms
+    pub fn all_algorithms(settings: &ClassificationSettings) -> Vec<Self> {
+        let mut algorithms = vec![Self::default_decision_tree_classifier()];
+        if settings.knn_classifier_settings.is_some() {
+            algorithms.push(Self::default_knn_classifier());
+        }
+        algorithms
+    }
+
+    /// Default decision tree classifier algorithm
+    #[must_use]
+    pub fn default_decision_tree_classifier() -> Self {
+        Self::DecisionTreeClassifier(
+            smartcore::tree::decision_tree_classifier::DecisionTreeClassifier::new(),
+        )
+    }
+
+    /// Default KNN classifier algorithm
+    #[must_use]
+    pub fn default_knn_classifier() -> Self {
+        Self::KNNClassifier(smartcore::neighbors::knn_classifier::KNNClassifier::new())
+    }
+}
+
+impl<INPUT, OUTPUT, InputArray, OutputArray> PartialEq
+    for ClassificationAlgorithm<INPUT, OUTPUT, InputArray, OutputArray>
+where
+    INPUT: RealNumber + FloatNumber,
+    OUTPUT: Number + Ord,
+    InputArray: MutArrayView2<INPUT>
+        + Sized
+        + Clone
+        + Array2<INPUT>
+        + QRDecomposable<INPUT>
+        + SVDDecomposable<INPUT>
+        + CholeskyDecomposable<INPUT>,
+    OutputArray: MutArrayView1<OUTPUT> + Sized + Clone + Array1<OUTPUT>,
+{
+    fn eq(&self, other: &Self) -> bool {
+        matches!(self, Self::DecisionTreeClassifier(_))
+            && matches!(other, Self::DecisionTreeClassifier(_))
+            || matches!(self, Self::KNNClassifier(_)) && matches!(other, Self::KNNClassifier(_))
+    }
+}
+
+impl<INPUT, OUTPUT, InputArray, OutputArray> Default
+    for ClassificationAlgorithm<INPUT, OUTPUT, InputArray, OutputArray>
+where
+    INPUT: RealNumber + FloatNumber,
+    OUTPUT: Number + Ord,
+    InputArray: MutArrayView2<INPUT>
+        + Sized
+        + Clone
+        + Array2<INPUT>
+        + QRDecomposable<INPUT>
+        + SVDDecomposable<INPUT>
+        + CholeskyDecomposable<INPUT>,
+    OutputArray: MutArrayView1<OUTPUT> + Sized + Clone + Array1<OUTPUT>,
+{
+    fn default() -> Self {
+        Self::default_decision_tree_classifier()
+    }
+}
+
+impl<INPUT, OUTPUT, InputArray, OutputArray> Display
+    for ClassificationAlgorithm<INPUT, OUTPUT, InputArray, OutputArray>
+where
+    INPUT: RealNumber + FloatNumber,
+    OUTPUT: Number + Ord,
+    InputArray: MutArrayView2<INPUT>
+        + Sized
+        + Clone
+        + Array2<INPUT>
+        + QRDecomposable<INPUT>
+        + SVDDecomposable<INPUT>
+        + CholeskyDecomposable<INPUT>,
+    OutputArray: MutArrayView1<OUTPUT> + Sized + Clone + Array1<OUTPUT>,
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::DecisionTreeClassifier(_) => write!(f, "Decision Tree Classifier"),
+            Self::KNNClassifier(_) => write!(f, "KNN Classifier"),
+        }
+    }
+}

--- a/src/settings/classification_algorithms.rs
+++ b/src/settings/classification_algorithms.rs
@@ -1,7 +1,9 @@
 //! Classification algorithm definitions and helpers.
 
 use std::fmt::{Display, Formatter};
-use std::time::{Duration, Instant};
+use std::time::Instant;
+
+use crate::model::ComparisonEntry;
 
 use super::ClassificationSettings;
 use smartcore::api::SupervisedEstimator;
@@ -185,15 +187,15 @@ where
         x: &InputArray,
         y: &OutputArray,
         settings: &ClassificationSettings,
-    ) -> (
-        CrossValidationResult,
-        ClassificationAlgorithm<INPUT, OUTPUT, InputArray, OutputArray>,
-        Duration,
-    ) {
+    ) -> ComparisonEntry<ClassificationAlgorithm<INPUT, OUTPUT, InputArray, OutputArray>> {
         let start = Instant::now();
         let results = self.cv(x, y, settings);
         let end = Instant::now();
-        (results.0, results.1, end.duration_since(start))
+        ComparisonEntry {
+            result: results.0,
+            algorithm: results.1,
+            duration: end.duration_since(start),
+        }
     }
 
     /// Get a vector of all possible algorithms

--- a/src/settings/classification_settings.rs
+++ b/src/settings/classification_settings.rs
@@ -1,0 +1,115 @@
+use super::{
+    DecisionTreeClassifierParameters, FinalAlgorithm, KNNClassifierParameters, Metric,
+    PreProcessing,
+};
+use smartcore::linalg::basic::arrays::Array1;
+use smartcore::numbers::basenum::Number;
+use smartcore::{metrics::accuracy, model_selection::KFold};
+
+/// Settings for classification models
+pub struct ClassificationSettings {
+    /// The metric to sort by
+    pub(crate) sort_by: Metric,
+    /// The number of folds for cross-validation
+    pub(crate) number_of_folds: usize,
+    /// Whether to shuffle the data
+    pub(crate) shuffle: bool,
+    /// Whether to be verbose
+    pub(crate) verbose: bool,
+    /// The approach to use for the final model
+    pub(crate) final_model_approach: FinalAlgorithm,
+    /// The kind of preprocessing to perform
+    pub(crate) preprocessing: PreProcessing,
+    /// Optional settings for KNN classifier
+    pub(crate) knn_classifier_settings: Option<KNNClassifierParameters>,
+    /// Optional settings for decision tree classifier
+    pub(crate) decision_tree_classifier_settings: Option<DecisionTreeClassifierParameters>,
+}
+
+impl Default for ClassificationSettings {
+    fn default() -> Self {
+        Self {
+            sort_by: Metric::Accuracy,
+            number_of_folds: 10,
+            shuffle: false,
+            verbose: false,
+            final_model_approach: FinalAlgorithm::Best,
+            preprocessing: PreProcessing::None,
+            knn_classifier_settings: Some(KNNClassifierParameters::default()),
+            decision_tree_classifier_settings: Some(DecisionTreeClassifierParameters::default()),
+        }
+    }
+}
+
+impl ClassificationSettings {
+    /// Get the k-fold cross-validator
+    pub(crate) fn get_kfolds(&self) -> KFold {
+        KFold::default()
+            .with_n_splits(self.number_of_folds)
+            .with_shuffle(self.shuffle)
+    }
+
+    pub(crate) fn get_metric<OUTPUT, OutputArray>(&self) -> fn(&OutputArray, &OutputArray) -> f64
+    where
+        OUTPUT: Number + Ord,
+        OutputArray: Array1<OUTPUT>,
+    {
+        match self.sort_by {
+            Metric::Accuracy => accuracy,
+            Metric::None => panic!("A metric must be set."),
+            _ => panic!("Unsupported metric for classification"),
+        }
+    }
+
+    /// Specify number of folds for cross-validation
+    #[must_use]
+    pub const fn with_number_of_folds(mut self, n: usize) -> Self {
+        self.number_of_folds = n;
+        self
+    }
+
+    /// Specify whether data should be shuffled
+    #[must_use]
+    pub const fn shuffle_data(mut self, shuffle: bool) -> Self {
+        self.shuffle = shuffle;
+        self
+    }
+
+    /// Specify whether to be verbose
+    #[must_use]
+    pub const fn verbose(mut self, verbose: bool) -> Self {
+        self.verbose = verbose;
+        self
+    }
+
+    /// Specify what type of preprocessing should be performed
+    #[must_use]
+    pub const fn with_preprocessing(mut self, pre: PreProcessing) -> Self {
+        self.preprocessing = pre;
+        self
+    }
+
+    /// Specify what type of final model to use
+    #[must_use]
+    pub fn with_final_model(mut self, approach: FinalAlgorithm) -> Self {
+        self.final_model_approach = approach;
+        self
+    }
+
+    /// Specify settings for KNN classifier
+    #[must_use]
+    pub const fn with_knn_classifier_settings(mut self, settings: KNNClassifierParameters) -> Self {
+        self.knn_classifier_settings = Some(settings);
+        self
+    }
+
+    /// Specify settings for decision tree classifier
+    #[must_use]
+    pub const fn with_decision_tree_classifier_settings(
+        mut self,
+        settings: DecisionTreeClassifierParameters,
+    ) -> Self {
+        self.decision_tree_classifier_settings = Some(settings);
+        self
+    }
+}

--- a/src/settings/display.rs
+++ b/src/settings/display.rs
@@ -23,7 +23,7 @@ use smartcore::numbers::realnum::RealNumber;
 
 use crate::utils::display::print_option;
 
-use super::{Algorithm, LinearRegressionSolverName, RidgeRegressionSolverName, Settings};
+use super::{LinearRegressionSolverName, RegressionAlgorithm, RidgeRegressionSolverName, Settings};
 
 impl<INPUT, OUTPUT, InputArray, OutputArray> Settings<INPUT, OUTPUT, InputArray, OutputArray>
 where
@@ -82,8 +82,10 @@ where
     fn add_linear_rows(&self, table: &mut Table) {
         table
             .add_row(vec![
-                Cell::new(Algorithm::<INPUT, OUTPUT, InputArray, OutputArray>::default_linear())
-                    .add_attribute(Attribute::Italic),
+                Cell::new(
+                    RegressionAlgorithm::<INPUT, OUTPUT, InputArray, OutputArray>::default_linear(),
+                )
+                .add_attribute(Attribute::Italic),
             ])
             .add_row(vec![
                 "    Solver",
@@ -98,8 +100,10 @@ where
     fn add_ridge_rows(&self, table: &mut Table) {
         table
             .add_row(vec![
-                Cell::new(Algorithm::<INPUT, OUTPUT, InputArray, OutputArray>::default_ridge())
-                    .add_attribute(Attribute::Italic),
+                Cell::new(
+                    RegressionAlgorithm::<INPUT, OUTPUT, InputArray, OutputArray>::default_ridge(),
+                )
+                .add_attribute(Attribute::Italic),
             ])
             .add_row(vec![
                 "    Solver",
@@ -122,8 +126,10 @@ where
     fn add_lasso_rows(&self, table: &mut Table) {
         table
             .add_row(vec![
-                Cell::new(Algorithm::<INPUT, OUTPUT, InputArray, OutputArray>::default_lasso())
-                    .add_attribute(Attribute::Italic),
+                Cell::new(
+                    RegressionAlgorithm::<INPUT, OUTPUT, InputArray, OutputArray>::default_lasso(),
+                )
+                .add_attribute(Attribute::Italic),
             ])
             .add_row(vec![
                 "    Alpha",
@@ -148,7 +154,7 @@ where
         table
             .add_row(vec![
                 Cell::new(
-                    Algorithm::<INPUT, OUTPUT, InputArray, OutputArray>::default_elastic_net(),
+                    RegressionAlgorithm::<INPUT, OUTPUT, InputArray, OutputArray>::default_elastic_net(),
                 )
                 .add_attribute(Attribute::Italic),
             ])
@@ -179,7 +185,7 @@ where
         table
             .add_row(vec![
                 Cell::new(
-                    Algorithm::<INPUT, OUTPUT, InputArray, OutputArray>::default_decision_tree(),
+                    RegressionAlgorithm::<INPUT, OUTPUT, InputArray, OutputArray>::default_decision_tree(),
                 )
                 .add_attribute(Attribute::Italic),
             ])
@@ -219,7 +225,7 @@ where
         table
             .add_row(vec![
                 Cell::new(
-                    Algorithm::<INPUT, OUTPUT, InputArray, OutputArray>::default_random_forest(),
+                    RegressionAlgorithm::<INPUT, OUTPUT, InputArray, OutputArray>::default_random_forest(),
                 )
                 .add_attribute(Attribute::Italic),
             ])
@@ -280,22 +286,40 @@ where
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let mut table = Self::init_table();
         self.add_general_rows(&mut table);
-        if !self.skiplist.contains(&Algorithm::default_linear()) {
+        if !self
+            .skiplist
+            .contains(&RegressionAlgorithm::default_linear())
+        {
             self.add_linear_rows(&mut table);
         }
-        if !self.skiplist.contains(&Algorithm::default_ridge()) {
+        if !self
+            .skiplist
+            .contains(&RegressionAlgorithm::default_ridge())
+        {
             self.add_ridge_rows(&mut table);
         }
-        if !self.skiplist.contains(&Algorithm::default_lasso()) {
+        if !self
+            .skiplist
+            .contains(&RegressionAlgorithm::default_lasso())
+        {
             self.add_lasso_rows(&mut table);
         }
-        if !self.skiplist.contains(&Algorithm::default_elastic_net()) {
+        if !self
+            .skiplist
+            .contains(&RegressionAlgorithm::default_elastic_net())
+        {
             self.add_elastic_net_rows(&mut table);
         }
-        if !self.skiplist.contains(&Algorithm::default_decision_tree()) {
+        if !self
+            .skiplist
+            .contains(&RegressionAlgorithm::default_decision_tree())
+        {
             self.add_decision_tree_rows(&mut table);
         }
-        if !self.skiplist.contains(&Algorithm::default_random_forest()) {
+        if !self
+            .skiplist
+            .contains(&RegressionAlgorithm::default_random_forest())
+        {
             self.add_random_forest_rows(&mut table);
         }
         writeln!(f, "{table}")

--- a/src/settings/display.rs
+++ b/src/settings/display.rs
@@ -21,9 +21,10 @@ use smartcore::linalg::traits::svd::SVDDecomposable;
 use smartcore::numbers::floatnum::FloatNumber;
 use smartcore::numbers::realnum::RealNumber;
 
+use crate::algorithms::RegressionAlgorithm;
 use crate::utils::display::print_option;
 
-use super::{LinearRegressionSolverName, RegressionAlgorithm, RidgeRegressionSolverName, Settings};
+use super::{LinearRegressionSolverName, RidgeRegressionSolverName, Settings};
 
 impl<INPUT, OUTPUT, InputArray, OutputArray> Settings<INPUT, OUTPUT, InputArray, OutputArray>
 where

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -3,13 +3,16 @@
 //! ## Complete regression customization
 //! ```
 //! use smartcore::linalg::basic::matrix::DenseMatrix;
-//! use automl::settings::{
-//!     RegressionAlgorithm, DecisionTreeRegressorParameters, Distance, ElasticNetParameters,
-//!     KNNAlgorithmName, KNNRegressorParameters, KNNWeightFunction, Kernel, LassoParameters,
-//!     LinearRegressionParameters, LinearRegressionSolverName, Metric,
-//!     RandomForestRegressorParameters, RidgeRegressionParameters, RidgeRegressionSolverName,
-//!     SVRParameters,
-//!  };
+//! use automl::{
+//!     algorithms::RegressionAlgorithm,
+//!     settings::{
+//!         DecisionTreeRegressorParameters, Distance, ElasticNetParameters, KNNAlgorithmName,
+//!         KNNRegressorParameters, KNNWeightFunction, Kernel, LassoParameters,
+//!         LinearRegressionParameters, LinearRegressionSolverName, Metric,
+//!         RandomForestRegressorParameters, RidgeRegressionParameters, RidgeRegressionSolverName,
+//!         SVRParameters,
+//!     },
+//! };
 //!
 //!  let settings = automl::Settings::<f64, f64, DenseMatrix<f64>, Vec<f64>>::default_regression()
 //!     .with_number_of_folds(3)
@@ -124,12 +127,6 @@ pub use knn_classifier_parameters::KNNClassifierParameters;
 
 mod svc_parameters;
 pub use svc_parameters::SVCParameters;
-
-mod regression_algorithms;
-pub use regression_algorithms::RegressionAlgorithm;
-
-mod classification_algorithms;
-pub use classification_algorithms::ClassificationAlgorithm;
 
 mod classification_settings;
 pub use classification_settings::ClassificationSettings;

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -4,7 +4,7 @@
 //! ```
 //! use smartcore::linalg::basic::matrix::DenseMatrix;
 //! use automl::settings::{
-//!     Algorithm, DecisionTreeRegressorParameters, Distance, ElasticNetParameters,
+//!     RegressionAlgorithm, DecisionTreeRegressorParameters, Distance, ElasticNetParameters,
 //!     KNNAlgorithmName, KNNRegressorParameters, KNNWeightFunction, Kernel, LassoParameters,
 //!     LinearRegressionParameters, LinearRegressionSolverName, Metric,
 //!     RandomForestRegressorParameters, RidgeRegressionParameters, RidgeRegressionSolverName,
@@ -15,7 +15,7 @@
 //!     .with_number_of_folds(3)
 //!     .shuffle_data(true)
 //!     .verbose(true)
-//!     .skip(Algorithm::default_random_forest())
+//!     .skip(RegressionAlgorithm::default_random_forest())
 //!     .sorted_by(Metric::RSquared)
 //!     .with_linear_settings(
 //!         LinearRegressionParameters::default().with_solver(LinearRegressionSolverName::QR),
@@ -125,8 +125,14 @@ pub use knn_classifier_parameters::KNNClassifierParameters;
 mod svc_parameters;
 pub use svc_parameters::SVCParameters;
 
-mod algorithms;
-pub use algorithms::Algorithm;
+mod regression_algorithms;
+pub use regression_algorithms::RegressionAlgorithm;
+
+mod classification_algorithms;
+pub use classification_algorithms::ClassificationAlgorithm;
+
+mod classification_settings;
+pub use classification_settings::ClassificationSettings;
 
 mod settings_struct;
 #[doc(no_inline)]
@@ -146,6 +152,8 @@ pub enum Metric {
     MeanAbsoluteError,
     /// Sort by MSE
     MeanSquaredError,
+    /// Sort by classification accuracy
+    Accuracy,
     /// Sort by none
     None,
 }
@@ -156,6 +164,7 @@ impl Display for Metric {
             Self::RSquared => write!(f, "R^2"),
             Self::MeanAbsoluteError => write!(f, "MAE"),
             Self::MeanSquaredError => write!(f, "MSE"),
+            Self::Accuracy => write!(f, "Accuracy"),
             Self::None => panic!("A metric must be set."),
         }
     }

--- a/src/settings/regression_algorithms.rs
+++ b/src/settings/regression_algorithms.rs
@@ -1,5 +1,5 @@
 //!
-//! Algorithm definitions and helpers
+//! RegressionAlgorithm definitions and helpers
 
 use std::fmt::{Display, Formatter};
 use std::time::{Duration, Instant};
@@ -18,8 +18,8 @@ use smartcore::model_selection::CrossValidationResult;
 use smartcore::numbers::floatnum::FloatNumber;
 use smartcore::numbers::realnum::RealNumber;
 
-/// Algorithm options
-pub enum Algorithm<INPUT, OUTPUT, InputArray, OutputArray>
+/// RegressionAlgorithm options
+pub enum RegressionAlgorithm<INPUT, OUTPUT, InputArray, OutputArray>
 where
     INPUT: RealNumber + FloatNumber,
     OUTPUT: FloatNumber,
@@ -114,7 +114,8 @@ where
     ),
 }
 
-impl<INPUT, OUTPUT, InputArray, OutputArray> Algorithm<INPUT, OUTPUT, InputArray, OutputArray>
+impl<INPUT, OUTPUT, InputArray, OutputArray>
+    RegressionAlgorithm<INPUT, OUTPUT, InputArray, OutputArray>
 where
     INPUT: RealNumber + FloatNumber,
     OUTPUT: FloatNumber,
@@ -265,10 +266,10 @@ where
         settings: &Settings<INPUT, OUTPUT, InputArray, OutputArray>,
     ) -> (
         CrossValidationResult,
-        Algorithm<INPUT, OUTPUT, InputArray, OutputArray>,
+        RegressionAlgorithm<INPUT, OUTPUT, InputArray, OutputArray>,
     ) {
         match self {
-            Algorithm::Linear(_) => (
+            RegressionAlgorithm::Linear(_) => (
                 smartcore::model_selection::cross_validate(
                     smartcore::linear::linear_regression::LinearRegression::<INPUT, OUTPUT, InputArray, OutputArray>::new(),
                     x,
@@ -280,9 +281,9 @@ where
                 .expect(
                     "Error during cross-validation. This is likely a bug in the AutoML library. Please open an issue on GitHub.",
                 ),
-                Algorithm::default_linear().fit(x, y, settings),
+                RegressionAlgorithm::default_linear().fit(x, y, settings),
             ),
-            Algorithm::Ridge(_) => (
+            RegressionAlgorithm::Ridge(_) => (
                 smartcore::model_selection::cross_validate(
                     smartcore::linear::ridge_regression::RidgeRegression::<INPUT, OUTPUT, InputArray, OutputArray>::new(),
                     x,
@@ -294,9 +295,9 @@ where
                 .expect(
                     "Error during cross-validation. This is likely a bug in the AutoML library. Please open an issue on GitHub.",
                 ),
-                Algorithm::default_ridge().fit(x, y, settings),
+                RegressionAlgorithm::default_ridge().fit(x, y, settings),
             ),
-            Algorithm::Lasso(_) => (
+            RegressionAlgorithm::Lasso(_) => (
                 smartcore::model_selection::cross_validate(
                     smartcore::linear::lasso::Lasso::<INPUT, OUTPUT, InputArray, OutputArray>::new(),
                     x,
@@ -308,9 +309,9 @@ where
                 .expect(
                     "Error during cross-validation. This is likely a bug in the AutoML library. Please open an issue on GitHub.",
                 ),
-                Algorithm::default_lasso().fit(x, y, settings),
+                RegressionAlgorithm::default_lasso().fit(x, y, settings),
             ),
-            Algorithm::ElasticNet(_) => (
+            RegressionAlgorithm::ElasticNet(_) => (
                 smartcore::model_selection::cross_validate(
                     smartcore::linear::elastic_net::ElasticNet::<INPUT, OUTPUT, InputArray, OutputArray>::new(),
                     x,
@@ -322,9 +323,9 @@ where
                 .expect(
                     "Error during cross-validation. This is likely a bug in the AutoML library. Please open an issue on GitHub.",
                 ),
-                Algorithm::default_elastic_net().fit(x, y, settings),
+                RegressionAlgorithm::default_elastic_net().fit(x, y, settings),
             ),
-            Algorithm::RandomForestRegressor(_) => (
+            RegressionAlgorithm::RandomForestRegressor(_) => (
                 smartcore::model_selection::cross_validate(
                     smartcore::ensemble::random_forest_regressor::RandomForestRegressor::<INPUT, OUTPUT, InputArray, OutputArray>::new(),
                     x,
@@ -340,9 +341,9 @@ where
                 .expect(
                     "Error during cross-validation. This is likely a bug in the AutoML library. Please open an issue on GitHub.",
                 ),
-                Algorithm::default_random_forest().fit(x, y, settings),
+                RegressionAlgorithm::default_random_forest().fit(x, y, settings),
             ),
-            Algorithm::DecisionTreeRegressor(_) => (
+            RegressionAlgorithm::DecisionTreeRegressor(_) => (
                 smartcore::model_selection::cross_validate(
                     smartcore::tree::decision_tree_regressor::DecisionTreeRegressor::new(),
                     x,
@@ -358,9 +359,9 @@ where
                 .expect(
                     "Error during cross-validation. This is likely a bug in the AutoML library",
                 ),
-                Algorithm::default_decision_tree().fit(x, y, settings),
+                RegressionAlgorithm::default_decision_tree().fit(x, y, settings),
             ),
-            Algorithm::KNNRegressorEuclidian(_) => (
+            RegressionAlgorithm::KNNRegressorEuclidian(_) => (
                 smartcore::model_selection::cross_validate(
                     smartcore::neighbors::knn_regressor::KNNRegressor::<
                         INPUT,
@@ -396,9 +397,9 @@ where
                 .expect(
                     "Error during cross-validation. This is likely a bug in the AutoML library",
                 ),
-                Algorithm::default_knn_regressor().fit(x, y, settings),
+                RegressionAlgorithm::default_knn_regressor().fit(x, y, settings),
             ),
-            Algorithm::KNNRegressorManhattan(_) => (
+            RegressionAlgorithm::KNNRegressorManhattan(_) => (
                 smartcore::model_selection::cross_validate(
                     smartcore::neighbors::knn_regressor::KNNRegressor::<
                         INPUT,
@@ -434,9 +435,9 @@ where
                 .expect(
                     "Error during cross-validation. This is likely a bug in the AutoML library",
                 ),
-                Algorithm::default_knn_regressor_manhattan().fit(x, y, settings),
+                RegressionAlgorithm::default_knn_regressor_manhattan().fit(x, y, settings),
             ),
-            Algorithm::KNNRegressorMinkowski(_) => {
+            RegressionAlgorithm::KNNRegressorMinkowski(_) => {
                 let Distance::Minkowski(p) = settings
                     .knn_regressor_settings
                     .as_ref()
@@ -481,10 +482,10 @@ where
                     .expect(
                         "Error during cross-validation. This is likely a bug in the AutoML library",
                     ),
-                    Algorithm::default_knn_regressor_minkowski().fit(x, y, settings),
+                    RegressionAlgorithm::default_knn_regressor_minkowski().fit(x, y, settings),
                 )
             }
-            Algorithm::KNNRegressorHamming(_) => (
+            RegressionAlgorithm::KNNRegressorHamming(_) => (
                 smartcore::model_selection::cross_validate(
                     smartcore::neighbors::knn_regressor::KNNRegressor::<
                         INPUT,
@@ -520,7 +521,7 @@ where
                 .expect(
                     "Error during cross-validation. This is likely a bug in the AutoML library",
                 ),
-                Algorithm::default_knn_regressor_hamming().fit(x, y, settings),
+                RegressionAlgorithm::default_knn_regressor_hamming().fit(x, y, settings),
             ),
         }
     }
@@ -532,7 +533,7 @@ where
         settings: &Settings<INPUT, OUTPUT, InputArray, OutputArray>,
     ) -> (
         CrossValidationResult,
-        Algorithm<INPUT, OUTPUT, InputArray, OutputArray>,
+        RegressionAlgorithm<INPUT, OUTPUT, InputArray, OutputArray>,
         Duration,
     ) {
         let start = Instant::now();
@@ -633,7 +634,7 @@ where
 }
 
 impl<INPUT, OUTPUT, InputArray, OutputArray> PartialEq
-    for Algorithm<INPUT, OUTPUT, InputArray, OutputArray>
+    for RegressionAlgorithm<INPUT, OUTPUT, InputArray, OutputArray>
 where
     INPUT: RealNumber + FloatNumber,
     OUTPUT: FloatNumber,
@@ -678,7 +679,7 @@ where
 }
 
 impl<INPUT, OUTPUT, InputArray, OutputArray> Default
-    for Algorithm<INPUT, OUTPUT, InputArray, OutputArray>
+    for RegressionAlgorithm<INPUT, OUTPUT, InputArray, OutputArray>
 where
     INPUT: RealNumber + FloatNumber,
     OUTPUT: FloatNumber,
@@ -692,12 +693,12 @@ where
     OutputArray: MutArrayView1<OUTPUT> + Sized + Clone + Array1<OUTPUT>,
 {
     fn default() -> Self {
-        Algorithm::Linear(smartcore::linear::linear_regression::LinearRegression::new())
+        RegressionAlgorithm::Linear(smartcore::linear::linear_regression::LinearRegression::new())
     }
 }
 
 impl<INPUT, OUTPUT, InputArray, OutputArray> Display
-    for Algorithm<INPUT, OUTPUT, InputArray, OutputArray>
+    for RegressionAlgorithm<INPUT, OUTPUT, InputArray, OutputArray>
 where
     INPUT: RealNumber + FloatNumber,
     OUTPUT: FloatNumber,

--- a/src/settings/regression_algorithms.rs
+++ b/src/settings/regression_algorithms.rs
@@ -2,7 +2,9 @@
 //! RegressionAlgorithm definitions and helpers
 
 use std::fmt::{Display, Formatter};
-use std::time::{Duration, Instant};
+use std::time::Instant;
+
+use crate::model::ComparisonEntry;
 
 use super::Settings;
 use crate::utils::distance::Distance;
@@ -531,15 +533,15 @@ where
         x: &InputArray,
         y: &OutputArray,
         settings: &Settings<INPUT, OUTPUT, InputArray, OutputArray>,
-    ) -> (
-        CrossValidationResult,
-        RegressionAlgorithm<INPUT, OUTPUT, InputArray, OutputArray>,
-        Duration,
-    ) {
+    ) -> ComparisonEntry<RegressionAlgorithm<INPUT, OUTPUT, InputArray, OutputArray>> {
         let start = Instant::now();
         let results = self.cv(x, y, settings);
         let end = Instant::now();
-        (results.0, results.1, end.duration_since(start))
+        ComparisonEntry {
+            result: results.0,
+            algorithm: results.1,
+            duration: end.duration_since(start),
+        }
     }
 
     /// Get a vector of all possible algorithms

--- a/src/settings/settings_struct.rs
+++ b/src/settings/settings_struct.rs
@@ -7,8 +7,9 @@ use super::{
     ElasticNetParameters, FinalAlgorithm, GaussianNBParameters, KNNClassifierParameters,
     KNNRegressorParameters, LassoParameters, LinearRegressionParameters,
     LogisticRegressionParameters, Metric, PreProcessing, RandomForestClassifierParameters,
-    RandomForestRegressorParameters, RegressionAlgorithm, RidgeRegressionParameters,
+    RandomForestRegressorParameters, RidgeRegressionParameters,
 };
+use crate::algorithms::RegressionAlgorithm;
 
 use smartcore::{
     metrics::{mean_absolute_error, mean_squared_error, r2},
@@ -244,7 +245,7 @@ where
     /// ```
     /// # use automl::Settings;
     /// # use smartcore::linalg::basic::matrix::DenseMatrix;
-    /// use automl::settings::RegressionAlgorithm;
+    /// use automl::algorithms::RegressionAlgorithm;
     /// let settings = Settings::<f64, f64, DenseMatrix<f64>, Vec<f64>>::default()
     ///     .skip(RegressionAlgorithm::default_random_forest());
     /// ```
@@ -261,7 +262,7 @@ where
     /// ```
     /// # use automl::Settings;
     /// # use smartcore::linalg::basic::matrix::DenseMatrix;
-    /// use automl::settings::RegressionAlgorithm;
+    /// use automl::algorithms::RegressionAlgorithm;
     /// let settings = Settings::<f64, f64, DenseMatrix<f64>, Vec<f64>>::default()
     ///     .only(&RegressionAlgorithm::default_random_forest());
     /// ```

--- a/src/settings/settings_struct.rs
+++ b/src/settings/settings_struct.rs
@@ -3,11 +3,11 @@
 #![allow(clippy::struct_field_names)]
 
 use super::{
-    Algorithm, CategoricalNBParameters, DecisionTreeClassifierParameters,
-    DecisionTreeRegressorParameters, ElasticNetParameters, FinalAlgorithm, GaussianNBParameters,
-    KNNClassifierParameters, KNNRegressorParameters, LassoParameters, LinearRegressionParameters,
+    CategoricalNBParameters, DecisionTreeClassifierParameters, DecisionTreeRegressorParameters,
+    ElasticNetParameters, FinalAlgorithm, GaussianNBParameters, KNNClassifierParameters,
+    KNNRegressorParameters, LassoParameters, LinearRegressionParameters,
     LogisticRegressionParameters, Metric, PreProcessing, RandomForestClassifierParameters,
-    RandomForestRegressorParameters, RidgeRegressionParameters,
+    RandomForestRegressorParameters, RegressionAlgorithm, RidgeRegressionParameters,
 };
 
 use smartcore::{
@@ -39,7 +39,7 @@ where
     /// The type of model to train
     pub(crate) model_type: ModelType,
     /// The algorithms to skip
-    pub(crate) skiplist: Vec<Algorithm<INPUT, OUTPUT, InputArray, OutputArray>>,
+    pub(crate) skiplist: Vec<RegressionAlgorithm<INPUT, OUTPUT, InputArray, OutputArray>>,
     /// The number of folds for cross-validation
     pub(crate) number_of_folds: usize,
     /// Whether to shuffle the data
@@ -92,13 +92,13 @@ where
             model_type: ModelType::None,
             final_model_approach: FinalAlgorithm::Best,
             skiplist: vec![
-                Algorithm::default_linear(),
-                Algorithm::default_lasso(),
-                Algorithm::default_ridge(),
-                Algorithm::default_elastic_net(),
-                Algorithm::default_decision_tree(),
-                Algorithm::default_random_forest(),
-                Algorithm::default_knn_regressor(),
+                RegressionAlgorithm::default_linear(),
+                RegressionAlgorithm::default_lasso(),
+                RegressionAlgorithm::default_ridge(),
+                RegressionAlgorithm::default_elastic_net(),
+                RegressionAlgorithm::default_decision_tree(),
+                RegressionAlgorithm::default_random_forest(),
+                RegressionAlgorithm::default_knn_regressor(),
             ],
             preprocessing: PreProcessing::None,
             number_of_folds: 10,
@@ -140,6 +140,7 @@ where
             Metric::RSquared => r2,
             Metric::MeanAbsoluteError => mean_absolute_error,
             Metric::MeanSquaredError => mean_squared_error,
+            Metric::Accuracy => panic!("Accuracy metric not supported for regression"),
             Metric::None => panic!("A metric must be set."),
         }
     }
@@ -243,11 +244,15 @@ where
     /// ```
     /// # use automl::Settings;
     /// # use smartcore::linalg::basic::matrix::DenseMatrix;
-    /// use automl::settings::Algorithm;
-    /// let settings = Settings::<f64, f64, DenseMatrix<f64>, Vec<f64>>::default().skip(Algorithm::default_random_forest());
+    /// use automl::settings::RegressionAlgorithm;
+    /// let settings = Settings::<f64, f64, DenseMatrix<f64>, Vec<f64>>::default()
+    ///     .skip(RegressionAlgorithm::default_random_forest());
     /// ```
     #[must_use]
-    pub fn skip(mut self, skip: Algorithm<INPUT, OUTPUT, InputArray, OutputArray>) -> Self {
+    pub fn skip(
+        mut self,
+        skip: RegressionAlgorithm<INPUT, OUTPUT, InputArray, OutputArray>,
+    ) -> Self {
         self.skiplist.push(skip);
         self
     }
@@ -256,11 +261,15 @@ where
     /// ```
     /// # use automl::Settings;
     /// # use smartcore::linalg::basic::matrix::DenseMatrix;
-    /// use automl::settings::Algorithm;
-    /// let settings = Settings::<f64, f64, DenseMatrix<f64>, Vec<f64>>::default().only(&Algorithm::default_random_forest());
+    /// use automl::settings::RegressionAlgorithm;
+    /// let settings = Settings::<f64, f64, DenseMatrix<f64>, Vec<f64>>::default()
+    ///     .only(&RegressionAlgorithm::default_random_forest());
     /// ```
     #[must_use]
-    pub fn only(mut self, only: &Algorithm<INPUT, OUTPUT, InputArray, OutputArray>) -> Self {
+    pub fn only(
+        mut self,
+        only: &RegressionAlgorithm<INPUT, OUTPUT, InputArray, OutputArray>,
+    ) -> Self {
         self.skiplist = Self::default().skiplist;
         self.skiplist.retain(|algo| algo != only);
         self

--- a/tests/algorithms.rs
+++ b/tests/algorithms.rs
@@ -1,4 +1,5 @@
-use automl::settings::{Distance, KNNRegressorParameters, RegressionAlgorithm};
+use automl::algorithms::RegressionAlgorithm;
+use automl::settings::{Distance, KNNRegressorParameters};
 use automl::{DenseMatrix, Settings};
 
 type Alg = RegressionAlgorithm<f64, f64, DenseMatrix<f64>, Vec<f64>>;

--- a/tests/algorithms.rs
+++ b/tests/algorithms.rs
@@ -1,7 +1,7 @@
-use automl::settings::{Algorithm, Distance, KNNRegressorParameters};
+use automl::settings::{Distance, KNNRegressorParameters, RegressionAlgorithm};
 use automl::{DenseMatrix, Settings};
 
-type Alg = Algorithm<f64, f64, DenseMatrix<f64>, Vec<f64>>;
+type Alg = RegressionAlgorithm<f64, f64, DenseMatrix<f64>, Vec<f64>>;
 
 #[test]
 fn default_equals_linear() {

--- a/tests/classification.rs
+++ b/tests/classification.rs
@@ -1,0 +1,21 @@
+#[path = "fixtures/classification_data.rs"]
+mod classification_data;
+
+use automl::settings::ClassificationSettings;
+use automl::{ClassificationModel, DenseMatrix};
+use classification_data::classification_testing_data;
+
+#[test]
+fn test_default_classification() {
+    let settings = ClassificationSettings::default();
+    test_from_settings(settings);
+}
+
+fn test_from_settings(settings: ClassificationSettings) {
+    let (x, y) = classification_testing_data();
+
+    let mut model = ClassificationModel::new(x, y, settings);
+    model.train();
+
+    model.predict(DenseMatrix::from_2d_array(&[&[0.0, 0.0], &[1.0, 1.0]]).unwrap());
+}

--- a/tests/fixtures/classification_data.rs
+++ b/tests/fixtures/classification_data.rs
@@ -1,0 +1,32 @@
+use smartcore::linalg::basic::matrix::DenseMatrix;
+
+/// Return classification data for tests and examples.
+///
+/// # Returns
+///
+/// * `(x, y)` - Feature matrix and target vector.
+pub fn classification_testing_data() -> (DenseMatrix<f64>, Vec<i32>) {
+    let x = DenseMatrix::from_2d_array(&[
+        &[0.0, 0.0],
+        &[0.1, 0.0],
+        &[0.0, 0.1],
+        &[0.1, 0.1],
+        &[0.9, 0.9],
+        &[1.0, 0.9],
+        &[0.9, 1.0],
+        &[1.0, 1.0],
+        &[0.0, 0.2],
+        &[0.2, 0.0],
+        &[0.0, 0.3],
+        &[0.3, 0.0],
+        &[0.8, 0.7],
+        &[0.7, 0.8],
+        &[0.8, 0.8],
+        &[0.7, 0.7],
+    ])
+    .unwrap();
+
+    let y = vec![0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 0, 1, 1, 1, 1];
+
+    (x, y)
+}

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -1,8 +1,8 @@
 #[path = "fixtures/regression_data.rs"]
 mod regression_data;
 
-use automl::settings::Algorithm;
-use automl::{DenseMatrix, Settings, SupervisedModel};
+use automl::settings::RegressionAlgorithm;
+use automl::{DenseMatrix, RegressionModel, Settings};
 use regression_data::regression_testing_data;
 
 #[test]
@@ -13,7 +13,8 @@ fn test_default_regression() {
 
 #[test]
 fn test_knn_only_regression() {
-    let settings = Settings::default_regression().only(&Algorithm::default_knn_regressor());
+    let settings =
+        Settings::default_regression().only(&RegressionAlgorithm::default_knn_regressor());
     test_from_settings(settings);
 }
 
@@ -22,7 +23,7 @@ fn test_from_settings(settings: Settings<f64, f64, DenseMatrix<f64>, Vec<f64>>) 
     let (x, y) = regression_testing_data();
 
     // Set up the regressor settings and load data
-    let mut regressor = SupervisedModel::new(x, y, settings);
+    let mut regressor = RegressionModel::new(x, y, settings);
 
     // Compare models
     regressor.train();

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -1,7 +1,7 @@
 #[path = "fixtures/regression_data.rs"]
 mod regression_data;
 
-use automl::settings::RegressionAlgorithm;
+use automl::algorithms::RegressionAlgorithm;
 use automl::{DenseMatrix, RegressionModel, Settings};
 use regression_data::regression_testing_data;
 

--- a/tests/settings_display.rs
+++ b/tests/settings_display.rs
@@ -1,4 +1,5 @@
-use automl::{DenseMatrix, Settings, settings::RegressionAlgorithm};
+use automl::algorithms::RegressionAlgorithm;
+use automl::{DenseMatrix, Settings};
 
 #[test]
 fn display_reflects_skiplist() {

--- a/tests/settings_display.rs
+++ b/tests/settings_display.rs
@@ -1,9 +1,9 @@
-use automl::{DenseMatrix, Settings, settings::Algorithm};
+use automl::{DenseMatrix, Settings, settings::RegressionAlgorithm};
 
 #[test]
 fn display_reflects_skiplist() {
     let settings = Settings::<f64, f64, DenseMatrix<f64>, Vec<f64>>::default_regression()
-        .skip(Algorithm::default_random_forest());
+        .skip(RegressionAlgorithm::default_random_forest());
     let output = format!("{settings}");
     assert!(output.contains("Linear Regressor"));
     assert_eq!(output.matches("Random Forest Regressor").count(), 1);


### PR DESCRIPTION
## Summary
- introduce `ClassificationSettings` and supporting classification algorithms
- add `ClassificationModel` for discrete label prediction
- update docs and examples for separate regression and classification flows

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b4c4c767d883258edcbb557e95d8d4