### PR TITLE
feat: add random forest classifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ let _model = RegressionModel::new(x, y, Settings::default_regression());
 ### Classification
 ```rust
 use automl::{ClassificationModel};
-use automl::settings::ClassificationSettings;
+use automl::settings::{ClassificationSettings, RandomForestClassifierParameters};
 use smartcore::linalg::basic::matrix::DenseMatrix;
 
 let x = DenseMatrix::from_2d_vec(&vec![
@@ -47,33 +47,31 @@ let x = DenseMatrix::from_2d_vec(&vec![
     vec![0.0, 1.0],
 ]).unwrap();
 let y = vec![0_i32, 1, 1, 0];
-let _model = ClassificationModel::new(x, y, ClassificationSettings::default());
+let settings = ClassificationSettings::default()
+    .with_random_forest_classifier_settings(
+        RandomForestClassifierParameters::default().with_n_trees(10),
+    );
+let _model = ClassificationModel::new(x, y, settings);
 ```
 
 Model comparison:
 
 ```text
-┌────────────────────────────────┬─────────────────────┬───────────────────┬──────────────────┐
-│ Model                          │ Time                │ Training Accuracy │ Testing Accuracy │
-╞════════════════════════════════╪═════════════════════╪═══════════════════╪══════════════════╡
-│ Random Forest Classifier       │ 835ms 393us 583ns   │ 1.00              │ 0.96             │
-├────────────────────────────────┼─────────────────────┼───────────────────┼──────────────────┤
-│ Logistic Regression Classifier │ 620ms 714us 583ns   │ 0.97              │ 0.95             │
-├────────────────────────────────┼─────────────────────┼───────────────────┼──────────────────┤
-│ Gaussian Naive Bayes           │ 6ms 529us           │ 0.94              │ 0.93             │
-├────────────────────────────────┼─────────────────────┼───────────────────┼──────────────────┤
-│ Categorical Naive Bayes        │ 2ms 922us 250ns     │ 0.96              │ 0.93             │
-├────────────────────────────────┼─────────────────────┼───────────────────┼──────────────────┤
-│ Decision Tree Classifier       │ 15ms 404us 750ns    │ 1.00              │ 0.93             │
-├────────────────────────────────┼─────────────────────┼───────────────────┼──────────────────┤
-│ KNN Classifier                 │ 28ms 874us 208ns    │ 0.96              │ 0.92             │
-└────────────────────────────────┴─────────────────────┴───────────────────┴──────────────────┘
+┌───────────────────────────────┬─────────────────────┬───────────────────┬──────────────────┐
+│ Model                         │ Time                │ Training Accuracy │ Testing Accuracy │
+╞═══════════════════════════════╪═════════════════════╪═══════════════════╪══════════════════╡
+│ Random Forest Classifier      │ 835ms 393us 583ns   │ 1.00              │ 0.96             │
+├───────────────────────────────┼─────────────────────┼───────────────────┼──────────────────┤
+│ Decision Tree Classifier      │ 15ms 404us 750ns    │ 1.00              │ 0.93             │
+├───────────────────────────────┼─────────────────────┼───────────────────┼──────────────────┤
+│ KNN Classifier                │ 28ms 874us 208ns    │ 0.96              │ 0.92             │
+└───────────────────────────────┴─────────────────────┴───────────────────┴──────────────────┘
 ```
 
 ## Capabilities
 - Feature Engineering: PCA, SVD, interaction terms, polynomial terms
 - Regression: Decision Tree, KNN, Random Forest, Linear, Ridge, LASSO, Elastic Net, Support Vector Regression
-- Classification: Random Forest, Decision Tree, Support Vector, Logistic Regression, KNN, Gaussian & Categorical Naive Bayes
+- Classification: Random Forest, Decision Tree, KNN
 - Meta-learning: Blending (experimental)
 - Persistence: Save/load settings and models
 

--- a/src/model/classification.rs
+++ b/src/model/classification.rs
@@ -82,6 +82,7 @@ where
             {
                 ClassificationAlgorithm::DecisionTreeClassifier(model) => model.predict(&x),
                 ClassificationAlgorithm::KNNClassifier(model) => model.predict(&x),
+                ClassificationAlgorithm::RandomForestClassifier(model) => model.predict(&x),
             }
             .expect(
                 "Error during inference. This is likely a bug in the AutoML library. Please open an issue on GitHub.",

--- a/src/settings/classification_settings.rs
+++ b/src/settings/classification_settings.rs
@@ -1,6 +1,6 @@
 use super::{
     DecisionTreeClassifierParameters, FinalAlgorithm, KNNClassifierParameters, Metric,
-    PreProcessing,
+    PreProcessing, RandomForestClassifierParameters,
 };
 use smartcore::linalg::basic::arrays::Array1;
 use smartcore::numbers::basenum::Number;
@@ -24,6 +24,8 @@ pub struct ClassificationSettings {
     pub(crate) knn_classifier_settings: Option<KNNClassifierParameters>,
     /// Optional settings for decision tree classifier
     pub(crate) decision_tree_classifier_settings: Option<DecisionTreeClassifierParameters>,
+    /// Optional settings for random forest classifier
+    pub(crate) random_forest_classifier_settings: Option<RandomForestClassifierParameters>,
 }
 
 impl Default for ClassificationSettings {
@@ -37,6 +39,7 @@ impl Default for ClassificationSettings {
             preprocessing: PreProcessing::None,
             knn_classifier_settings: Some(KNNClassifierParameters::default()),
             decision_tree_classifier_settings: Some(DecisionTreeClassifierParameters::default()),
+            random_forest_classifier_settings: Some(RandomForestClassifierParameters::default()),
         }
     }
 }
@@ -110,6 +113,16 @@ impl ClassificationSettings {
         settings: DecisionTreeClassifierParameters,
     ) -> Self {
         self.decision_tree_classifier_settings = Some(settings);
+        self
+    }
+
+    /// Specify settings for random forest classifier
+    #[must_use]
+    pub const fn with_random_forest_classifier_settings(
+        mut self,
+        settings: RandomForestClassifierParameters,
+    ) -> Self {
+        self.random_forest_classifier_settings = Some(settings);
         self
     }
 }

--- a/tests/classification.rs
+++ b/tests/classification.rs
@@ -1,14 +1,31 @@
 #[path = "fixtures/classification_data.rs"]
 mod classification_data;
 
-use automl::settings::ClassificationSettings;
+use automl::algorithms::ClassificationAlgorithm;
+use automl::settings::{ClassificationSettings, RandomForestClassifierParameters};
 use automl::{ClassificationModel, DenseMatrix};
 use classification_data::classification_testing_data;
 
 #[test]
 fn test_default_classification() {
-    let settings = ClassificationSettings::default();
+    let settings = ClassificationSettings::default()
+        .with_number_of_folds(3)
+        .with_random_forest_classifier_settings(
+            RandomForestClassifierParameters::default().with_n_trees(10),
+        );
     test_from_settings(settings);
+}
+
+#[test]
+fn test_all_algorithms_included() {
+    let settings = ClassificationSettings::default();
+    let algorithms =
+        ClassificationAlgorithm::<f64, i32, DenseMatrix<f64>, Vec<i32>>::all_algorithms(&settings);
+    assert!(
+        algorithms
+            .iter()
+            .any(|a| matches!(a, ClassificationAlgorithm::RandomForestClassifier(_)))
+    );
 }
 
 fn test_from_settings(settings: ClassificationSettings) {


### PR DESCRIPTION
## Summary
- support random forest classifiers in AutoML comparisons
- document and test new classification option

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo audit`
- `cargo test --doc`


------
https://chatgpt.com/codex/tasks/task_e_68b4cf9950308325abaeba206b5fb27a