### PR TITLE
Add minimal and maximal classification examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ let y = vec![0_i32, 1, 1, 0];
 let _model = ClassificationModel::new(x, y, ClassificationSettings::default());
 ```
 
+Additional runnable examples are available in the [`examples/` directory](examples),
+including [`minimal_classification.rs`](examples/minimal_classification.rs) and
+[`maximal_classification.rs`](examples/maximal_classification.rs).
+
 Model comparison:
 
 ```text

--- a/examples/maximal_classification.rs
+++ b/examples/maximal_classification.rs
@@ -1,0 +1,62 @@
+#![allow(clippy::needless_doctest_main)]
+//! Maximal classification example
+//!
+//! This example demonstrates the maximal steps required to run a model
+//! comparison using the `ClassificationModel` API. It loads a small classification
+//! fixture, builds custom classification settings, trains all configured
+//! algorithms using cross-validation, and prints a comparison table.
+//!
+//! Run with:
+//!
+//! ```bash
+//! cargo run --example maximal_classification
+//! ```
+
+#[path = "../tests/fixtures/classification_data.rs"]
+mod classification_data;
+
+use automl::settings::ClassificationSettings;
+use automl::settings::{
+    DecisionTreeClassifierParameters, Distance, FinalAlgorithm, KNNAlgorithmName,
+    KNNClassifierParameters, KNNWeightFunction,
+};
+use automl::{ClassificationModel, DenseMatrix};
+use classification_data::classification_testing_data;
+
+fn main() {
+    // Load some classification data
+    let (x, y) = classification_testing_data();
+
+    // Customize settings
+    let settings = ClassificationSettings::default()
+        .with_number_of_folds(3)
+        .shuffle_data(true)
+        .verbose(true)
+        .with_final_model(FinalAlgorithm::Best)
+        .with_knn_classifier_settings(
+            KNNClassifierParameters::default()
+                .with_algorithm(KNNAlgorithmName::CoverTree)
+                .with_k(3)
+                .with_distance(Distance::Euclidean)
+                .with_weight(KNNWeightFunction::Uniform),
+        )
+        .with_decision_tree_classifier_settings(
+            DecisionTreeClassifierParameters::default()
+                .with_min_samples_split(2)
+                .with_max_depth(15)
+                .with_min_samples_leaf(1),
+        );
+
+    // Load a dataset and add it to the classifier along with the customized settings
+    let mut model = ClassificationModel::new(x, y, settings);
+
+    // Run a model comparison with all models at customized settings
+    model.train();
+
+    // Print the results
+    println!("{model}");
+
+    // Predict with the model, be sure to use a DenseMatrix
+    let preds = model.predict(DenseMatrix::from_2d_vec(&vec![vec![0.5_f64, 0.5]; 5]).unwrap());
+    println!("Predictions: {preds:?}");
+}

--- a/examples/minimal_classification.rs
+++ b/examples/minimal_classification.rs
@@ -1,0 +1,34 @@
+#![allow(clippy::needless_doctest_main)]
+//! Minimal classification example
+//!
+//! This example demonstrates the minimal steps required to run a model
+//! comparison using the `ClassificationModel` API. It loads a small classification
+//! fixture, builds default classification settings, trains all configured
+//! algorithms using cross-validation.
+//!
+//! Run with:
+//!
+//! ```bash
+//! cargo run --example minimal_classification
+//! ```
+
+#[path = "../tests/fixtures/classification_data.rs"]
+mod classification_data;
+
+use automl::ClassificationModel;
+use automl::settings::ClassificationSettings;
+use classification_data::classification_testing_data;
+
+fn main() {
+    // Load some classification data
+    let (x, y) = classification_testing_data();
+
+    // Build default classification settings
+    let settings = ClassificationSettings::default();
+
+    // Load a dataset from smartcore and add it to the classifier along with the settings
+    let mut model = ClassificationModel::new(x, y, settings);
+
+    // Run a model comparison with all models at default settings
+    model.train();
+}


### PR DESCRIPTION
## Summary
- add minimal classification example using default settings
- add maximal classification example with custom settings and predictions
- document available classification examples in README

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo test --doc`
- `cargo audit`
- `cargo run --example minimal_classification`
- `cargo run --example maximal_classification`


------
https://chatgpt.com/codex/tasks/task_e_68b4d032e2c08325a22a8030bd7e064f