### PR TITLE
feat: add logistic regression classifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Model comparison:
 ## Capabilities
 - Feature Engineering: PCA, SVD, interaction terms, polynomial terms
 - Regression: Decision Tree, KNN, Random Forest, Linear, Ridge, LASSO, Elastic Net, Support Vector Regression
-- Classification: Random Forest, Decision Tree, KNN
+- Classification: Random Forest, Decision Tree, KNN, Logistic Regression
 - Meta-learning: Blending (experimental)
 - Persistence: Save/load settings and models
 

--- a/src/model/classification.rs
+++ b/src/model/classification.rs
@@ -83,6 +83,7 @@ where
                 ClassificationAlgorithm::DecisionTreeClassifier(model) => model.predict(&x),
                 ClassificationAlgorithm::KNNClassifier(model) => model.predict(&x),
                 ClassificationAlgorithm::RandomForestClassifier(model) => model.predict(&x),
+                ClassificationAlgorithm::LogisticRegression(model) => model.predict(&x),
             }
             .expect(
                 "Error during inference. This is likely a bug in the AutoML library. Please open an issue on GitHub.",

--- a/src/settings/classification_settings.rs
+++ b/src/settings/classification_settings.rs
@@ -1,6 +1,6 @@
 use super::{
-    DecisionTreeClassifierParameters, FinalAlgorithm, KNNClassifierParameters, Metric,
-    PreProcessing, RandomForestClassifierParameters,
+    DecisionTreeClassifierParameters, FinalAlgorithm, KNNClassifierParameters,
+    LogisticRegressionParameters, Metric, PreProcessing, RandomForestClassifierParameters,
 };
 use smartcore::linalg::basic::arrays::Array1;
 use smartcore::numbers::basenum::Number;
@@ -26,6 +26,8 @@ pub struct ClassificationSettings {
     pub(crate) decision_tree_classifier_settings: Option<DecisionTreeClassifierParameters>,
     /// Optional settings for random forest classifier
     pub(crate) random_forest_classifier_settings: Option<RandomForestClassifierParameters>,
+    /// Optional settings for logistic regression classifier
+    pub(crate) logistic_regression_settings: Option<LogisticRegressionParameters<f64>>,
 }
 
 impl Default for ClassificationSettings {
@@ -40,6 +42,7 @@ impl Default for ClassificationSettings {
             knn_classifier_settings: Some(KNNClassifierParameters::default()),
             decision_tree_classifier_settings: Some(DecisionTreeClassifierParameters::default()),
             random_forest_classifier_settings: Some(RandomForestClassifierParameters::default()),
+            logistic_regression_settings: Some(LogisticRegressionParameters::default()),
         }
     }
 }
@@ -123,6 +126,16 @@ impl ClassificationSettings {
         settings: RandomForestClassifierParameters,
     ) -> Self {
         self.random_forest_classifier_settings = Some(settings);
+        self
+    }
+
+    /// Specify settings for logistic regression classifier
+    #[must_use]
+    pub const fn with_logistic_regression_settings(
+        mut self,
+        settings: LogisticRegressionParameters<f64>,
+    ) -> Self {
+        self.logistic_regression_settings = Some(settings);
         self
     }
 }

--- a/tests/classification.rs
+++ b/tests/classification.rs
@@ -26,6 +26,11 @@ fn test_all_algorithms_included() {
             .iter()
             .any(|a| matches!(a, ClassificationAlgorithm::RandomForestClassifier(_)))
     );
+    assert!(
+        algorithms
+            .iter()
+            .any(|a| matches!(a, ClassificationAlgorithm::LogisticRegression(_)))
+    );
 }
 
 fn test_from_settings(settings: ClassificationSettings) {


### PR DESCRIPTION
## Summary
- add logistic regression as built-in classification algorithm
- expose logistic regression settings and default builder
- document logistic regression support and add regression test

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo test --doc`
- `cargo audit`


------
https://chatgpt.com/codex/tasks/task_e_68b4d39fcf8c83259308cfb033db3fd1