### PR TITLE
feat: extend distance traits and tests

### DIFF
--- a/src/utils/distance.rs
+++ b/src/utils/distance.rs
@@ -3,7 +3,7 @@
 use std::fmt::{Display, Formatter};
 
 /// Distance metrics
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum Distance {
     /// Euclidean distance
     Euclidean,
@@ -26,7 +26,7 @@ impl Display for Distance {
         match self {
             Self::Euclidean => write!(f, "Euclidean"),
             Self::Manhattan => write!(f, "Manhattan"),
-            Self::Minkowski(n) => write!(f, "Minkowski\n    p = {n}"),
+            Self::Minkowski(n) => write!(f, "Minkowski(p = {n})"),
             Self::Mahalanobis => write!(f, "Mahalanobis"),
             Self::Hamming => write!(f, "Hamming"),
         }

--- a/tests/distance.rs
+++ b/tests/distance.rs
@@ -1,0 +1,20 @@
+use automl::utils::Distance;
+
+#[allow(clippy::clone_on_copy)]
+fn assert_traits(dist: Distance, display: &str, debug: &str) {
+    let copy = dist;
+    assert_eq!(copy, dist);
+    let cloned = dist.clone();
+    assert_eq!(cloned, dist);
+    assert_eq!(format!("{dist}"), display);
+    assert_eq!(format!("{dist:?}"), debug);
+}
+
+#[test]
+fn distance_trait_behaviors_and_display() {
+    assert_traits(Distance::Euclidean, "Euclidean", "Euclidean");
+    assert_traits(Distance::Manhattan, "Manhattan", "Manhattan");
+    assert_traits(Distance::Minkowski(4), "Minkowski(p = 4)", "Minkowski(4)");
+    assert_traits(Distance::Mahalanobis, "Mahalanobis", "Mahalanobis");
+    assert_traits(Distance::Hamming, "Hamming", "Hamming");
+}


### PR DESCRIPTION
## Summary
- derive common traits for `Distance`
- render `Minkowski` inline via `Display`
- test `Distance` trait behavior and `Display`

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings -W clippy::pedantic`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b4f7d6d794832590f7496d706b33c6