### PR TITLE
Add doctests and unit tests for display helpers

### DIFF
--- a/src/utils/display.rs
+++ b/src/utils/display.rs
@@ -3,17 +3,48 @@
 use smartcore::{algorithm::neighbour::KNNAlgorithmName, neighbors::KNNWeightFunction};
 use std::fmt::{Debug, Display};
 
-/// Convert an `Option<T>` to a String for printing in display mode.
+/// Convert an `Option<T>` to a `String` for printing in display mode.
+///
+/// # Examples
+/// ```
+/// use automl::utils::display::print_option;
+///
+/// let value = Some(5);
+/// let none: Option<i32> = None;
+/// assert_eq!(print_option(value), "5");
+/// assert_eq!(print_option(none), "None");
+/// ```
+#[must_use]
 pub fn print_option<T: Display>(x: Option<T>) -> String {
     x.map_or_else(|| "None".to_string(), |y| format!("{y}"))
 }
 
-/// Convert an `Option<T>` to a String for printing in debug mode.
+/// Convert an `Option<T>` to a `String` for printing in debug mode.
+///
+/// # Examples
+/// ```
+/// use automl::utils::display::debug_option;
+///
+/// let complex_output = debug_option(Some(vec![1, 2]));
+/// assert_eq!(complex_output, "[\n    1,\n    2,\n]");
+/// let none: Option<i32> = None;
+/// assert_eq!(debug_option(none), "None");
+/// ```
+#[must_use]
 pub fn debug_option<T: Debug>(x: Option<T>) -> String {
     x.map_or_else(|| "None".to_string(), |y| format!("{y:#?}"))
 }
 
-/// Get the name for a knn weight function.
+/// Get the name for a KNN weight function.
+///
+/// # Examples
+/// ```
+/// use automl::utils::display::print_knn_weight_function;
+/// use smartcore::neighbors::KNNWeightFunction;
+///
+/// assert_eq!(print_knn_weight_function(&KNNWeightFunction::Uniform), "Uniform");
+/// assert_eq!(print_knn_weight_function(&KNNWeightFunction::Distance), "Distance");
+/// ```
 #[must_use]
 pub fn print_knn_weight_function(f: &KNNWeightFunction) -> String {
     match f {
@@ -22,7 +53,22 @@ pub fn print_knn_weight_function(f: &KNNWeightFunction) -> String {
     }
 }
 
-/// Get the name for a knn search algorithm.
+/// Get the name for a KNN search algorithm.
+///
+/// # Examples
+/// ```
+/// use automl::utils::display::print_knn_search_algorithm;
+/// use smartcore::algorithm::neighbour::KNNAlgorithmName;
+///
+/// assert_eq!(
+///     print_knn_search_algorithm(&KNNAlgorithmName::LinearSearch),
+///     "Linear Search"
+/// );
+/// assert_eq!(
+///     print_knn_search_algorithm(&KNNAlgorithmName::CoverTree),
+///     "Cover Tree"
+/// );
+/// ```
 #[must_use]
 pub fn print_knn_search_algorithm(a: &KNNAlgorithmName) -> String {
     match a {

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -1,0 +1,113 @@
+use automl::utils::display::{
+    debug_option, print_knn_search_algorithm, print_knn_weight_function, print_option,
+};
+use smartcore::algorithm::neighbour::KNNAlgorithmName;
+use smartcore::neighbors::KNNWeightFunction;
+
+#[test]
+fn print_option_returns_value_for_some() {
+    // Arrange
+    let value = Some(10);
+
+    // Act
+    let output = print_option(value);
+
+    // Assert
+    assert_eq!(output, "10");
+}
+
+#[test]
+fn print_option_returns_none_for_none() {
+    // Arrange
+    let value: Option<i32> = None;
+
+    // Act
+    let output = print_option(value);
+
+    // Assert
+    assert_eq!(output, "None");
+}
+
+#[test]
+fn debug_option_formats_value() {
+    // Arrange
+    let value = Some(42);
+
+    // Act
+    let output = debug_option(value);
+
+    // Assert
+    assert_eq!(output, "42");
+}
+
+#[test]
+fn debug_option_formats_complex_value() {
+    // Arrange
+    let value = Some(vec![1, 2]);
+
+    // Act
+    let output = debug_option(value);
+
+    // Assert
+    assert_eq!(output, "[\n    1,\n    2,\n]");
+}
+
+#[test]
+fn debug_option_formats_none() {
+    // Arrange
+    let value: Option<i32> = None;
+
+    // Act
+    let output = debug_option(value);
+
+    // Assert
+    assert_eq!(output, "None");
+}
+
+#[test]
+fn print_knn_weight_function_uniform() {
+    // Arrange
+    let weight = KNNWeightFunction::Uniform;
+
+    // Act
+    let output = print_knn_weight_function(&weight);
+
+    // Assert
+    assert_eq!(output, "Uniform");
+}
+
+#[test]
+fn print_knn_weight_function_distance() {
+    // Arrange
+    let weight = KNNWeightFunction::Distance;
+
+    // Act
+    let output = print_knn_weight_function(&weight);
+
+    // Assert
+    assert_eq!(output, "Distance");
+}
+
+#[test]
+fn print_knn_search_algorithm_linear_search() {
+    // Arrange
+    let algorithm = KNNAlgorithmName::LinearSearch;
+
+    // Act
+    let output = print_knn_search_algorithm(&algorithm);
+
+    // Assert
+    assert_eq!(output, "Linear Search");
+}
+
+#[test]
+fn print_knn_search_algorithm_cover_tree() {
+    // Arrange
+    let algorithm = KNNAlgorithmName::CoverTree;
+
+    // Act
+    let output = print_knn_search_algorithm(&algorithm);
+
+    // Assert
+    assert_eq!(output, "Cover Tree");
+}


### PR DESCRIPTION
## Summary
- add `# Examples` doctests for display utilities
- test option and KNN display helpers across typical and edge cases
- mark option helpers as `#[must_use]` and clarify debug doctest

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings -W clippy::pedantic`
- `cargo test`
- `cargo test --doc`


------
https://chatgpt.com/codex/tasks/task_e_68b4f7dfcf3883259a5cbd856f8b6cc1