### PR TITLE
ci: run cargo audit on schedule

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,29 @@
+name: security-audit
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libclang-dev libgtk-3-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev libssl-dev
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install cargo-audit
+        run: cargo install cargo-audit
+      - name: Audit
+        run: cargo audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,28 +48,9 @@ jobs:
       - name: Clippy
         run: cargo clippy --all-targets -- -D warnings -D clippy::pedantic
 
-  audit:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y libclang-dev libgtk-3-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev libssl-dev
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - uses: dtolnay/rust-toolchain@stable
-      - name: Install cargo-audit
-        run: cargo install cargo-audit
-      - name: Audit
-        run: cargo audit
-
   doc:
     runs-on: ubuntu-latest
-    needs: [fmt, clippy, audit]
+    needs: [fmt, clippy]
     steps:
       - uses: actions/checkout@v4
       - name: Install system dependencies
@@ -91,7 +72,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    needs: [fmt, clippy, audit]
+    needs: [fmt, clippy]
     steps:
       - uses: actions/checkout@v4
       - name: Install system dependencies

--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ cargo audit
 cargo test --doc
 ```
 
+Security audits run weekly via a scheduled workflow, but running `cargo audit` locally before submitting changes helps catch issues earlier.
+
 Pull requests are welcome!
 
 ## License


### PR DESCRIPTION
## Summary
- remove `cargo audit` from main CI workflow
- add scheduled security audit job
- document weekly audit run in development guide

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings -D clippy::pedantic`
- `cargo test`
- `cargo test --doc`
- `cargo audit --json`


------
https://chatgpt.com/codex/tasks/task_e_68b4fa1cf26c8325a3c28e27c3d0e75a