### PR TITLE
Propagate clustering errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ use automl::utils::load_csv_features;
 let x = load_csv_features("tests/fixtures/clustering_points.csv").unwrap();
 let mut model = ClusteringModel::new(x.clone(), ClusteringSettings::default().with_k(2));
 model.train();
-let clusters: Vec<u8> = model.predict(&x);
+let clusters: Vec<u8> = model.predict(&x).unwrap();
 ```
 
 ## Examples
@@ -93,7 +93,7 @@ let x = DenseMatrix::from_2d_vec(&vec![
 ]).unwrap();
   let mut model = ClusteringModel::new(x.clone(), ClusteringSettings::default().with_k(2));
   model.train();
-  let _clusters: Vec<u8> = model.predict(&x);
+  let _clusters: Vec<u8> = model.predict(&x).unwrap();
   ```
 
 Additional runnable examples are available in the [`examples/` directory](examples),

--- a/examples/maximal_clustering.rs
+++ b/examples/maximal_clustering.rs
@@ -36,6 +36,6 @@ fn main() {
 
     // Predict cluster assignments for new data
     let new_points = DenseMatrix::from_2d_vec(&vec![vec![0.9_f64, 1.1], vec![8.1, 8.3]]).unwrap();
-    let clusters: Vec<u8> = model.predict(&new_points);
+    let clusters: Vec<u8> = model.predict(&new_points).expect("prediction failed");
     println!("Predicted clusters: {clusters:?}");
 }

--- a/examples/minimal_clustering.rs
+++ b/examples/minimal_clustering.rs
@@ -26,6 +26,6 @@ fn main() {
     model.train();
 
     // Predict cluster assignments
-    let clusters: Vec<u8> = model.predict(&x);
+    let clusters: Vec<u8> = model.predict(&x).expect("prediction failed");
     println!("Predicted clusters: {clusters:?}");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,6 @@ pub use algorithms::{ClassificationAlgorithm, ClusteringAlgorithm, RegressionAlg
 
 /// Model definitions and implementations.
 pub mod model;
-pub use model::{ClassificationModel, ClusteringModel, RegressionModel};
+pub use model::{ClassificationModel, ClusteringModel, ModelError, ModelResult, RegressionModel};
 
 pub use smartcore::linalg::basic::matrix::DenseMatrix;

--- a/src/model/clustering.rs
+++ b/src/model/clustering.rs
@@ -1,6 +1,7 @@
 //! Implementation of clustering model training.
 
 use crate::algorithms::ClusteringAlgorithm;
+use crate::model::{ModelError, ModelResult};
 use crate::settings::{ClusteringAlgorithmName, ClusteringSettings};
 use smartcore::linalg::basic::arrays::{Array1, Array2};
 use smartcore::numbers::{basenum::Number, floatnum::FloatNumber, realnum::RealNumber};
@@ -51,13 +52,13 @@ where
 
     /// Predict cluster assignments for new data.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if the model has not been trained.
-    pub fn predict(&self, x: &InputArray) -> ClusterArray {
+    /// Returns [`ModelError::NotTrained`] if the model has not been trained.
+    pub fn predict(&self, x: &InputArray) -> ModelResult<ClusterArray> {
         match &self.algorithm {
             Some(alg) => alg.predict(x, &self.settings),
-            None => panic!("Model has not been trained"),
+            None => Err(ModelError::NotTrained),
         }
     }
 }

--- a/src/model/error.rs
+++ b/src/model/error.rs
@@ -1,0 +1,30 @@
+//! Shared model errors.
+
+use std::error::Error;
+use std::fmt::{self, Display, Formatter};
+
+/// Errors that can occur when using models.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ModelError {
+    /// Attempted to use a model before training.
+    NotTrained,
+    /// The predicted cluster label could not be converted to the target type.
+    InvalidClusterLabel(usize),
+    /// Underlying algorithm failed during inference.
+    Inference(String),
+}
+
+impl Display for ModelError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotTrained => write!(f, "model has not been trained"),
+            Self::InvalidClusterLabel(l) => write!(f, "invalid cluster label {l}"),
+            Self::Inference(msg) => write!(f, "inference error: {msg}"),
+        }
+    }
+}
+
+impl Error for ModelError {}
+
+/// Convenience type alias for results produced by models.
+pub type ModelResult<T> = Result<T, ModelError>;

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -3,10 +3,12 @@
 pub mod classification;
 pub mod clustering;
 mod comparison;
+pub mod error;
 mod preprocessing;
 pub mod regression;
 
 pub use classification::ClassificationModel;
 pub use clustering::ClusteringModel;
 pub use comparison::ComparisonEntry;
+pub use error::{ModelError, ModelResult};
 pub use regression::RegressionModel;

--- a/src/utils/io.rs
+++ b/src/utils/io.rs
@@ -61,7 +61,7 @@ impl Error for CsvError {
 /// let settings = ClusteringSettings::default().with_k(2);
 /// let mut model = ClusteringModel::new(x.clone(), settings);
 /// model.train();
-/// let clusters: Vec<u8> = model.predict(&x);
+/// let clusters: Vec<u8> = model.predict(&x)?;
 /// # Ok(())
 /// # }
 /// ```


### PR DESCRIPTION
## Summary
- introduce `ModelError` and `ModelResult` for shared error handling
- return `Result` from clustering models instead of panicking
- document new API and add regression test for untrained model

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings -W clippy::pedantic`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b4ffae30248325ab3681e4cbc25a39