### PR TITLE
feat: add clustering metrics to display

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ let _model = ClassificationModel::new(x, y, settings);
 
 ### Clustering
 ```rust
-use automl::{ClusteringModel};
+use automl::ClusteringModel;
 use automl::settings::ClusteringSettings;
 use smartcore::linalg::basic::matrix::DenseMatrix;
 
@@ -91,10 +91,13 @@ let x = DenseMatrix::from_2d_vec(&vec![
     vec![8.0, 8.0],
     vec![8.2, 8.2],
 ]).unwrap();
-  let mut model = ClusteringModel::new(x.clone(), ClusteringSettings::default().with_k(2));
-  model.train();
-  let _clusters: Vec<u8> = model.predict(&x);
-  ```
+let mut model = ClusteringModel::new(x.clone(), ClusteringSettings::default().with_k(2));
+model.train();
+let truth = vec![1_u8, 1, 2, 2];
+model.evaluate(&truth);
+println!("{model}");
+let _clusters: Vec<u8> = model.predict(&x);
+```
 
 Additional runnable examples are available in the [`examples/` directory](examples),
 including [`minimal_classification.rs`](examples/minimal_classification.rs),

--- a/src/model/clustering.rs
+++ b/src/model/clustering.rs
@@ -1,15 +1,22 @@
 //! Implementation of clustering model training.
 
-use crate::algorithms::ClusteringAlgorithm;
 use crate::settings::{ClusteringAlgorithmName, ClusteringSettings};
+use crate::{
+    algorithms::ClusteringAlgorithm,
+    metrics::{ClusterMetrics, HCVScore},
+};
+use comfy_table::{
+    Attribute, Cell, Table, modifiers::UTF8_SOLID_INNER_BORDERS, presets::UTF8_FULL,
+};
 use smartcore::linalg::basic::arrays::{Array1, Array2};
 use smartcore::numbers::{basenum::Number, floatnum::FloatNumber, realnum::RealNumber};
+use std::fmt::{Display, Formatter};
 
 /// Trains clustering models
 pub struct ClusteringModel<INPUT, CLUSTER, InputArray, ClusterArray>
 where
     INPUT: RealNumber + FloatNumber,
-    CLUSTER: Number,
+    CLUSTER: Number + Ord,
     InputArray: Array2<INPUT> + Clone,
     ClusterArray: Array1<CLUSTER> + Clone + std::iter::FromIterator<CLUSTER>,
 {
@@ -19,13 +26,15 @@ where
     x_train: InputArray,
     /// The fitted algorithm.
     algorithm: Option<ClusteringAlgorithm<INPUT, CLUSTER, InputArray, ClusterArray>>,
+    /// Optional clustering evaluation metrics.
+    metrics: Option<HCVScore<CLUSTER>>,
 }
 
 impl<INPUT, CLUSTER, InputArray, ClusterArray>
     ClusteringModel<INPUT, CLUSTER, InputArray, ClusterArray>
 where
     INPUT: RealNumber + FloatNumber,
-    CLUSTER: Number,
+    CLUSTER: Number + Ord,
     InputArray: Array2<INPUT> + Clone,
     ClusterArray: Array1<CLUSTER> + Clone + std::iter::FromIterator<CLUSTER>,
 {
@@ -35,6 +44,7 @@ where
             settings,
             x_train: x,
             algorithm: None,
+            metrics: None,
         }
     }
 
@@ -59,5 +69,60 @@ where
             Some(alg) => alg.predict(x, &self.settings),
             None => panic!("Model has not been trained"),
         }
+    }
+
+    /// Evaluate clustering results against known labels.
+    ///
+    /// # Arguments
+    /// * `truth` - Ground truth cluster labels.
+    pub fn evaluate(&mut self, truth: &ClusterArray) {
+        let predicted = self.predict(&self.x_train);
+        let mut scores = ClusterMetrics::<CLUSTER>::hcv_score();
+        scores.compute(truth, &predicted);
+        self.metrics = Some(scores);
+    }
+}
+
+impl<INPUT, CLUSTER, InputArray, ClusterArray> Display
+    for ClusteringModel<INPUT, CLUSTER, InputArray, ClusterArray>
+where
+    INPUT: RealNumber + FloatNumber,
+    CLUSTER: Number + Ord,
+    InputArray: Array2<INPUT> + Clone,
+    ClusterArray: Array1<CLUSTER> + Clone + std::iter::FromIterator<CLUSTER>,
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let mut table = Table::new();
+        table.load_preset(UTF8_FULL);
+        table.apply_modifier(UTF8_SOLID_INNER_BORDERS);
+        table.set_header(vec![
+            Cell::new("Model").add_attribute(Attribute::Bold),
+            Cell::new("Homogeneity").add_attribute(Attribute::Bold),
+            Cell::new("Completeness").add_attribute(Attribute::Bold),
+            Cell::new("V-Measure").add_attribute(Attribute::Bold),
+        ]);
+
+        let algorithm = match &self.algorithm {
+            Some(alg) => alg.to_string(),
+            None => "Untrained".to_string(),
+        };
+
+        let (homogeneity, completeness, v_measure) = if let Some(scores) = &self.metrics {
+            let format_score = |s: Option<f64>| match s {
+                Some(val) => format!("{val:.2}"),
+                None => "-".to_string(),
+            };
+            (
+                format_score(scores.homogeneity()),
+                format_score(scores.completeness()),
+                format_score(scores.v_measure()),
+            )
+        } else {
+            ("-".to_string(), "-".to_string(), "-".to_string())
+        };
+
+        table.add_row(vec![algorithm, homogeneity, completeness, v_measure]);
+
+        write!(f, "{table}")
     }
 }

--- a/tests/clustering.rs
+++ b/tests/clustering.rs
@@ -7,6 +7,7 @@ use automl::{
     settings::{ClusteringAlgorithmName, ClusteringSettings},
 };
 use clustering_data::clustering_testing_data;
+use smartcore::linalg::basic::matrix::DenseMatrix;
 
 #[test]
 fn kmeans_clustering_runs() {
@@ -53,4 +54,23 @@ fn clustering_metrics_compute() {
     assert!((scores.homogeneity().unwrap() - 1.0).abs() < 1e-12);
     assert!((scores.completeness().unwrap() - 1.0).abs() < 1e-12);
     assert!((scores.v_measure().unwrap() - 1.0).abs() < 1e-12);
+}
+
+#[test]
+fn clustering_model_display_shows_metrics() {
+    // Arrange
+    let x = clustering_testing_data();
+    let mut model: ClusteringModel<f64, u8, DenseMatrix<f64>, Vec<u8>> =
+        ClusteringModel::new(x.clone(), ClusteringSettings::default().with_k(2));
+    model.train();
+    let truth = vec![1_u8, 1, 2, 2];
+    model.evaluate(&truth);
+
+    // Act
+    let output = format!("{model}");
+
+    // Assert
+    assert!(output.contains("KMeans"));
+    assert!(output.contains("V-Measure"));
+    assert!(output.contains("1.00"));
 }


### PR DESCRIPTION
## Summary
- compute homogeneity, completeness, and v-measure for clustering models
- show clustering metrics in `ClusteringModel` display output
- document and test clustering metrics display

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings -D clippy::pedantic`
- `cargo test`
- `cargo test --doc`
- `cargo audit`


------
https://chatgpt.com/codex/tasks/task_e_68b5004cef9c83259d7695de413a740c