### PR TITLE
refactor: propagate regression errors

### DIFF
--- a/examples/maximal_regression.rs
+++ b/examples/maximal_regression.rs
@@ -26,8 +26,9 @@ use automl::{
     },
 };
 use regression_data::regression_testing_data;
+use smartcore::error::Failed;
 
-fn main() {
+fn main() -> Result<(), Failed> {
     // Load some regression data
     let (x, y) = regression_testing_data();
 
@@ -97,12 +98,13 @@ fn main() {
     let mut model = RegressionModel::new(x, y, settings);
 
     // Run a model comparison with all models at default settings
-    model.train();
+    model.train()?;
 
     // Print the results
     println!("{model}");
 
     // Predict with the model, be sure to use a DenseMatrix
-    let preds = model.predict(DenseMatrix::from_2d_vec(&vec![vec![5.0_f64; 6]; 10]).unwrap());
+    let preds = model.predict(DenseMatrix::from_2d_vec(&vec![vec![5.0_f64; 6]; 10])?)?;
     println!("Predictions: {preds:?}");
+    Ok(())
 }

--- a/examples/minimal_regression.rs
+++ b/examples/minimal_regression.rs
@@ -17,8 +17,9 @@ mod regression_data;
 
 use automl::{RegressionModel, RegressionSettings};
 use regression_data::regression_testing_data;
+use smartcore::error::Failed;
 
-fn main() {
+fn main() -> Result<(), Failed> {
     // Load some regression data
     let (x, y) = regression_testing_data();
 
@@ -29,5 +30,6 @@ fn main() {
     let mut model = RegressionModel::new(x, y, settings);
 
     // Run a model comparison with all models at default settings
-    model.train();
+    model.train()?;
+    Ok(())
 }

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -4,21 +4,24 @@ mod regression_data;
 use automl::algorithms::RegressionAlgorithm;
 use automl::{DenseMatrix, RegressionModel, RegressionSettings};
 use regression_data::regression_testing_data;
+use smartcore::error::Failed;
 
 #[test]
-fn test_default_regression() {
+fn test_default_regression() -> Result<(), Failed> {
     let settings = RegressionSettings::default();
-    test_from_settings(settings);
+    test_from_settings(settings)
 }
 
 #[test]
-fn test_knn_only_regression() {
+fn test_knn_only_regression() -> Result<(), Failed> {
     let settings =
         RegressionSettings::default().only(&RegressionAlgorithm::default_knn_regressor());
-    test_from_settings(settings);
+    test_from_settings(settings)
 }
 
-fn test_from_settings(settings: RegressionSettings<f64, f64, DenseMatrix<f64>, Vec<f64>>) {
+fn test_from_settings(
+    settings: RegressionSettings<f64, f64, DenseMatrix<f64>, Vec<f64>>,
+) -> Result<(), Failed> {
     // Get test data
     let (x, y) = regression_testing_data();
 
@@ -26,14 +29,12 @@ fn test_from_settings(settings: RegressionSettings<f64, f64, DenseMatrix<f64>, V
     let mut regressor = RegressionModel::new(x, y, settings);
 
     // Compare models
-    regressor.train();
+    regressor.train()?;
 
     // Try to predict something
-    regressor.predict(
-        DenseMatrix::from_2d_array(&[
-            &[234.289, 235.6, 159.0, 107.608, 1947., 60.323],
-            &[259.426, 232.5, 145.6, 108.632, 1948., 61.122],
-        ])
-        .unwrap(),
-    );
+    regressor.predict(DenseMatrix::from_2d_array(&[
+        &[234.289, 235.6, 159.0, 107.608, 1947., 60.323],
+        &[259.426, 232.5, 145.6, 108.632, 1948., 61.122],
+    ])?)?;
+    Ok(())
 }


### PR DESCRIPTION
## Summary
- propagate smartcore errors in regression algorithm training and cross-validation
- return `Result` from regression model `train` and `predict`
- update examples and tests for new `Result`-based APIs
- document training errors to satisfy clippy pedantic

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings -W clippy::pedantic`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b503c19900832594ba4a42673dba6c