### PR TITLE
Refactor KNN parameter setup with shared builders

### DIFF
--- a/src/algorithms/classification.rs
+++ b/src/algorithms/classification.rs
@@ -4,7 +4,7 @@ use std::fmt::{Display, Formatter};
 use std::time::Instant;
 
 use crate::model::ComparisonEntry;
-use crate::settings::ClassificationSettings;
+use crate::settings::{ClassificationSettings, build_knn_classifier_parameters};
 use smartcore::api::SupervisedEstimator;
 use smartcore::linalg::basic::arrays::{Array1, Array2, MutArrayView1, MutArrayView2};
 use smartcore::linalg::traits::cholesky::CholeskyDecomposable;
@@ -110,25 +110,10 @@ where
                 smartcore::neighbors::knn_classifier::KNNClassifier::fit(
                     x,
                     y,
-                    smartcore::neighbors::knn_classifier::KNNClassifierParameters::default()
-                        .with_k(settings.knn_classifier_settings.as_ref().unwrap().k)
-                        .with_algorithm(
-                            settings
-                                .knn_classifier_settings
-                                .as_ref()
-                                .unwrap()
-                                .algorithm
-                                .clone(),
-                        )
-                        .with_weight(
-                            settings
-                                .knn_classifier_settings
-                                .as_ref()
-                                .unwrap()
-                                .weight
-                                .clone(),
-                        )
-                        .with_distance(Euclidian::new()),
+                    build_knn_classifier_parameters::<INPUT, _>(
+                        settings.knn_classifier_settings.as_ref().unwrap(),
+                        Euclidian::new(),
+                    ),
                 )
                 .expect(
                     "Error during training. This is likely a bug in the AutoML library. Please open an issue on GitHub.",
@@ -209,25 +194,10 @@ where
                     smartcore::neighbors::knn_classifier::KNNClassifier::new(),
                     x,
                     y,
-                    smartcore::neighbors::knn_classifier::KNNClassifierParameters::default()
-                        .with_k(settings.knn_classifier_settings.as_ref().unwrap().k)
-                        .with_algorithm(
-                            settings
-                                .knn_classifier_settings
-                                .as_ref()
-                                .unwrap()
-                                .algorithm
-                                .clone(),
-                        )
-                        .with_weight(
-                            settings
-                                .knn_classifier_settings
-                                .as_ref()
-                                .unwrap()
-                                .weight
-                                .clone(),
-                        )
-                        .with_distance(Euclidian::new()),
+                    build_knn_classifier_parameters::<INPUT, _>(
+                        settings.knn_classifier_settings.as_ref().unwrap(),
+                        Euclidian::new(),
+                    ),
                     &settings.get_kfolds(),
                     &settings.get_metric::<OUTPUT, OutputArray>(),
                 )

--- a/src/algorithms/regression.rs
+++ b/src/algorithms/regression.rs
@@ -5,7 +5,7 @@ use std::fmt::{Display, Formatter};
 use std::time::Instant;
 
 use crate::model::ComparisonEntry;
-use crate::settings::RegressionSettings;
+use crate::settings::{RegressionSettings, build_knn_regressor_parameters};
 use crate::utils::distance::Distance;
 use smartcore::api::SupervisedEstimator;
 use smartcore::linalg::basic::arrays::{Array1, Array2, MutArrayView1, MutArrayView2};
@@ -192,17 +192,23 @@ where
                 smartcore::neighbors::knn_regressor::KNNRegressor::fit(
                     x,
                     y,
-                    smartcore::neighbors::knn_regressor::KNNRegressorParameters::default().with_k(settings.knn_regressor_settings.as_ref().unwrap().k).with_algorithm(settings.knn_regressor_settings.as_ref().unwrap().algorithm.clone()).with_weight(settings.knn_regressor_settings.as_ref().unwrap().weight.clone()).with_distance(Euclidian::new()),
-                )
-                    .expect(
-                        "Error during training. This is likely a bug in the AutoML library. Please open an issue on GitHub.",
+                    build_knn_regressor_parameters::<INPUT, _>(
+                        settings.knn_regressor_settings.as_ref().unwrap(),
+                        Euclidian::new(),
                     ),
+                )
+                .expect(
+                    "Error during training. This is likely a bug in the AutoML library. Please open an issue on GitHub.",
+                ),
             ),
             Self::KNNRegressorManhattan(_) => Self::KNNRegressorManhattan(
                 smartcore::neighbors::knn_regressor::KNNRegressor::fit(
                     x,
                     y,
-                    smartcore::neighbors::knn_regressor::KNNRegressorParameters::default().with_k(settings.knn_regressor_settings.as_ref().unwrap().k).with_algorithm(settings.knn_regressor_settings.as_ref().unwrap().algorithm.clone()).with_weight(settings.knn_regressor_settings.as_ref().unwrap().weight.clone()).with_distance(Manhattan::new()),
+                    build_knn_regressor_parameters::<INPUT, _>(
+                        settings.knn_regressor_settings.as_ref().unwrap(),
+                        Manhattan::new(),
+                    ),
                 )
                 .expect(
                     "Error during training. This is likely a bug in the AutoML library. Please open an issue on GitHub.",
@@ -221,25 +227,10 @@ where
                     smartcore::neighbors::knn_regressor::KNNRegressor::fit(
                         x,
                         y,
-                        smartcore::neighbors::knn_regressor::KNNRegressorParameters::default()
-                            .with_k(settings.knn_regressor_settings.as_ref().unwrap().k)
-                            .with_algorithm(
-                                settings
-                                    .knn_regressor_settings
-                                    .as_ref()
-                                    .unwrap()
-                                    .algorithm
-                                    .clone(),
-                            )
-                            .with_weight(
-                                settings
-                                    .knn_regressor_settings
-                                    .as_ref()
-                                    .unwrap()
-                                    .weight
-                                    .clone(),
-                            )
-                            .with_distance(Minkowski::new(p)),
+                        build_knn_regressor_parameters::<INPUT, _>(
+                            settings.knn_regressor_settings.as_ref().unwrap(),
+                            Minkowski::new(p),
+                        )
                     )
                     .expect(
                         "Error during training. This is likely a bug in the AutoML library. Please open an issue on GitHub.",
@@ -250,7 +241,10 @@ where
                 smartcore::neighbors::knn_regressor::KNNRegressor::fit(
                     x,
                     y,
-                    smartcore::neighbors::knn_regressor::KNNRegressorParameters::default().with_k(settings.knn_regressor_settings.as_ref().unwrap().k).with_algorithm(settings.knn_regressor_settings.as_ref().unwrap().algorithm.clone()).with_weight(settings.knn_regressor_settings.as_ref().unwrap().weight.clone()).with_distance(Hamming::new()),
+                    build_knn_regressor_parameters::<INPUT, _>(
+                        settings.knn_regressor_settings.as_ref().unwrap(),
+                        Hamming::new(),
+                    ),
                 )
                     .expect(
                         "Error during training. This is likely a bug in the AutoML library. Please open an issue on GitHub.",
@@ -373,25 +367,10 @@ where
                     >::new(),
                     x,
                     y,
-                    smartcore::neighbors::knn_regressor::KNNRegressorParameters::default()
-                        .with_k(settings.knn_regressor_settings.as_ref().unwrap().k)
-                        .with_algorithm(
-                            settings
-                                .knn_regressor_settings
-                                .as_ref()
-                                .unwrap()
-                                .algorithm
-                                .clone(),
-                        )
-                        .with_weight(
-                            settings
-                                .knn_regressor_settings
-                                .as_ref()
-                                .unwrap()
-                                .weight
-                                .clone(),
-                        )
-                        .with_distance(Euclidian::new()),
+                    build_knn_regressor_parameters::<INPUT, _>(
+                        settings.knn_regressor_settings.as_ref().unwrap(),
+                        Euclidian::new(),
+                    ),
                     &settings.get_kfolds(),
                     &settings.get_metric(),
                 )
@@ -411,25 +390,10 @@ where
                     >::new(),
                     x,
                     y,
-                    smartcore::neighbors::knn_regressor::KNNRegressorParameters::default()
-                        .with_k(settings.knn_regressor_settings.as_ref().unwrap().k)
-                        .with_algorithm(
-                            settings
-                                .knn_regressor_settings
-                                .as_ref()
-                                .unwrap()
-                                .algorithm
-                                .clone(),
-                        )
-                        .with_weight(
-                            settings
-                                .knn_regressor_settings
-                                .as_ref()
-                                .unwrap()
-                                .weight
-                                .clone(),
-                        )
-                        .with_distance(Manhattan::new()),
+                    build_knn_regressor_parameters::<INPUT, _>(
+                        settings.knn_regressor_settings.as_ref().unwrap(),
+                        Manhattan::new(),
+                    ),
                     &settings.get_kfolds(),
                     &settings.get_metric(),
                 )
@@ -458,25 +422,10 @@ where
                         >::new(),
                         x,
                         y,
-                        smartcore::neighbors::knn_regressor::KNNRegressorParameters::default()
-                            .with_k(settings.knn_regressor_settings.as_ref().unwrap().k)
-                            .with_algorithm(
-                                settings
-                                    .knn_regressor_settings
-                                    .as_ref()
-                                    .unwrap()
-                                    .algorithm
-                                    .clone(),
-                            )
-                            .with_weight(
-                                settings
-                                    .knn_regressor_settings
-                                    .as_ref()
-                                    .unwrap()
-                                    .weight
-                                    .clone(),
-                            )
-                            .with_distance(Minkowski::new(p)),
+                        build_knn_regressor_parameters::<INPUT, _>(
+                            settings.knn_regressor_settings.as_ref().unwrap(),
+                            Minkowski::new(p),
+                        ),
                         &settings.get_kfolds(),
                         &settings.get_metric(),
                     )
@@ -497,25 +446,10 @@ where
                     >::new(),
                     x,
                     y,
-                    smartcore::neighbors::knn_regressor::KNNRegressorParameters::default()
-                        .with_k(settings.knn_regressor_settings.as_ref().unwrap().k)
-                        .with_algorithm(
-                            settings
-                                .knn_regressor_settings
-                                .as_ref()
-                                .unwrap()
-                                .algorithm
-                                .clone(),
-                        )
-                        .with_weight(
-                            settings
-                                .knn_regressor_settings
-                                .as_ref()
-                                .unwrap()
-                                .weight
-                                .clone(),
-                        )
-                        .with_distance(Hamming::new()),
+                    build_knn_regressor_parameters::<INPUT, _>(
+                        settings.knn_regressor_settings.as_ref().unwrap(),
+                        Hamming::new(),
+                    ),
                     &settings.get_kfolds(),
                     &settings.get_metric(),
                 )

--- a/src/settings/knn_common.rs
+++ b/src/settings/knn_common.rs
@@ -1,0 +1,59 @@
+//! Helpers for constructing Smartcore KNN parameter structs from shared settings.
+
+use super::{KNNClassifierParameters, KNNRegressorParameters};
+use smartcore::metrics::distance::Distance as SmartDistance;
+use smartcore::neighbors::knn_classifier::KNNClassifierParameters as SmartKNNClassifierParameters;
+use smartcore::neighbors::knn_regressor::KNNRegressorParameters as SmartKNNRegressorParameters;
+use smartcore::numbers::basenum::Number;
+
+/// Build Smartcore KNN regressor parameters from common settings.
+///
+/// # Examples
+/// ```
+/// use automl::settings::{build_knn_regressor_parameters, KNNRegressorParameters};
+/// use smartcore::metrics::distance::euclidian::Euclidian;
+///
+/// let settings = KNNRegressorParameters::default().with_k(5);
+/// let params = build_knn_regressor_parameters::<f64, _>(&settings, Euclidian::new());
+/// assert_eq!(params.k, 5);
+/// ```
+pub fn build_knn_regressor_parameters<T, D>(
+    settings: &KNNRegressorParameters,
+    distance: D,
+) -> SmartKNNRegressorParameters<T, D>
+where
+    T: Number,
+    D: SmartDistance<Vec<T>>,
+{
+    SmartKNNRegressorParameters::<T, _>::default()
+        .with_k(settings.k)
+        .with_algorithm(settings.algorithm.clone())
+        .with_weight(settings.weight.clone())
+        .with_distance(distance)
+}
+
+/// Build Smartcore KNN classifier parameters from common settings.
+///
+/// # Examples
+/// ```
+/// use automl::settings::{build_knn_classifier_parameters, KNNClassifierParameters};
+/// use smartcore::metrics::distance::euclidian::Euclidian;
+///
+/// let settings = KNNClassifierParameters::default().with_k(7);
+/// let params = build_knn_classifier_parameters::<f64, _>(&settings, Euclidian::new());
+/// assert_eq!(params.k, 7);
+/// ```
+pub fn build_knn_classifier_parameters<T, D>(
+    settings: &KNNClassifierParameters,
+    distance: D,
+) -> SmartKNNClassifierParameters<T, D>
+where
+    T: Number,
+    D: SmartDistance<Vec<T>>,
+{
+    SmartKNNClassifierParameters::<T, _>::default()
+        .with_k(settings.k)
+        .with_algorithm(settings.algorithm.clone())
+        .with_weight(settings.weight.clone())
+        .with_distance(distance)
+}

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -125,6 +125,9 @@ pub use svr_parameters::SVRParameters;
 mod knn_classifier_parameters;
 pub use knn_classifier_parameters::KNNClassifierParameters;
 
+mod knn_common;
+pub use knn_common::{build_knn_classifier_parameters, build_knn_regressor_parameters};
+
 mod svc_parameters;
 pub use svc_parameters::SVCParameters;
 

--- a/tests/classification.rs
+++ b/tests/classification.rs
@@ -2,9 +2,13 @@
 mod classification_data;
 
 use automl::algorithms::ClassificationAlgorithm;
-use automl::settings::{ClassificationSettings, RandomForestClassifierParameters};
+use automl::settings::{
+    ClassificationSettings, KNNAlgorithmName, KNNClassifierParameters, KNNWeightFunction,
+    RandomForestClassifierParameters, build_knn_classifier_parameters,
+};
 use automl::{ClassificationModel, DenseMatrix};
 use classification_data::classification_testing_data;
+use smartcore::metrics::distance::euclidian::Euclidian;
 
 #[test]
 fn test_default_classification() {
@@ -31,6 +35,18 @@ fn test_all_algorithms_included() {
             .iter()
             .any(|a| matches!(a, ClassificationAlgorithm::LogisticRegression(_)))
     );
+}
+
+#[test]
+fn test_build_knn_classifier_parameters_helper() {
+    let settings = KNNClassifierParameters::default()
+        .with_k(4)
+        .with_algorithm(KNNAlgorithmName::LinearSearch)
+        .with_weight(KNNWeightFunction::Distance);
+    let params = build_knn_classifier_parameters::<f64, _>(&settings, Euclidian::new());
+    assert_eq!(params.k, 4);
+    assert!(matches!(params.algorithm, KNNAlgorithmName::LinearSearch));
+    assert!(matches!(params.weight, KNNWeightFunction::Distance));
 }
 
 fn test_from_settings(settings: ClassificationSettings) {

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -2,8 +2,12 @@
 mod regression_data;
 
 use automl::algorithms::RegressionAlgorithm;
+use automl::settings::{
+    KNNAlgorithmName, KNNRegressorParameters, KNNWeightFunction, build_knn_regressor_parameters,
+};
 use automl::{DenseMatrix, RegressionModel, RegressionSettings};
 use regression_data::regression_testing_data;
+use smartcore::metrics::distance::manhattan::Manhattan;
 
 #[test]
 fn test_default_regression() {
@@ -16,6 +20,18 @@ fn test_knn_only_regression() {
     let settings =
         RegressionSettings::default().only(&RegressionAlgorithm::default_knn_regressor());
     test_from_settings(settings);
+}
+
+#[test]
+fn test_build_knn_regressor_parameters_helper() {
+    let settings = KNNRegressorParameters::default()
+        .with_k(3)
+        .with_algorithm(KNNAlgorithmName::CoverTree)
+        .with_weight(KNNWeightFunction::Uniform);
+    let params = build_knn_regressor_parameters::<f64, _>(&settings, Manhattan::new());
+    assert_eq!(params.k, 3);
+    assert!(matches!(params.algorithm, KNNAlgorithmName::CoverTree));
+    assert!(matches!(params.weight, KNNWeightFunction::Uniform));
 }
 
 fn test_from_settings(settings: RegressionSettings<f64, f64, DenseMatrix<f64>, Vec<f64>>) {


### PR DESCRIPTION
## Summary
- centralize Smartcore KNN parameter construction in new `build_knn_*_parameters` helpers
- refactor classification and regression algorithms to use the shared builders
- add unit tests for the new helpers

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b504ec9a888325a1933a5625e96e03