### PR TITLE
Refactor supervised training with shared settings and trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ model.train();
 let truth = vec![1_u8, 1, 2, 2];
 model.evaluate(&truth);
 println!("{model}");
-let _clusters: Vec<u8> = model.predict(&x);
+let _clusters: Vec<u8> = model.predict(&x).expect("prediction");
 ```
 
 Additional runnable examples are available in the [`examples/` directory](examples),

--- a/examples/maximal_classification.rs
+++ b/examples/maximal_classification.rs
@@ -51,7 +51,7 @@ fn main() {
     let mut model = ClassificationModel::new(x, y, settings);
 
     // Run a model comparison with all models at customized settings
-    model.train();
+    model.train().unwrap();
 
     // Print the results
     println!("{model}");

--- a/examples/minimal_classification.rs
+++ b/examples/minimal_classification.rs
@@ -30,5 +30,5 @@ fn main() {
     let mut model = ClassificationModel::new(x, y, settings);
 
     // Run a model comparison with all models at default settings
-    model.train();
+    model.train().unwrap();
 }

--- a/src/algorithms/mod.rs
+++ b/src/algorithms/mod.rs
@@ -8,3 +8,7 @@ pub use classification::ClassificationAlgorithm;
 
 pub mod clustering;
 pub use clustering::ClusteringAlgorithm;
+
+/// Shared training utilities for supervised algorithms.
+pub mod supervised_train;
+pub use supervised_train::SupervisedTrain;

--- a/src/algorithms/supervised_train.rs
+++ b/src/algorithms/supervised_train.rs
@@ -1,0 +1,74 @@
+use smartcore::api::SupervisedEstimator;
+use smartcore::error::Failed;
+use smartcore::linalg::basic::arrays::{Array1, Array2};
+use smartcore::model_selection::{CrossValidationResult, KFold};
+
+/// Trait encapsulating shared training logic for supervised algorithms.
+pub trait SupervisedTrain<INPUT, OUTPUT, InputArray, OutputArray, Settings>
+where
+    INPUT: smartcore::numbers::realnum::RealNumber
+        + smartcore::numbers::basenum::Number
+        + Copy
+        + std::fmt::Debug
+        + std::fmt::Display,
+    OUTPUT: smartcore::numbers::basenum::Number + Copy + std::fmt::Debug + std::fmt::Display,
+    InputArray: Clone + Array2<INPUT>,
+    OutputArray: Clone + Array1<OUTPUT>,
+{
+    /// Fit the algorithm using provided settings.
+    #[allow(clippy::missing_errors_doc)]
+    fn fit_inner(
+        self,
+        x: &InputArray,
+        y: &OutputArray,
+        settings: &Settings,
+    ) -> Result<Self, Failed>
+    where
+        Self: Sized;
+
+    /// Perform cross-validation for the algorithm.
+    #[allow(clippy::missing_errors_doc)]
+    fn cv(
+        self,
+        x: &InputArray,
+        y: &OutputArray,
+        settings: &Settings,
+    ) -> Result<(CrossValidationResult, Self), Failed>
+    where
+        Self: Sized;
+
+    /// Retrieve the metric function for evaluation.
+    fn metric(settings: &Settings) -> fn(&OutputArray, &OutputArray) -> f64;
+
+    /// Shared implementation of cross-validation and fitting.
+    #[allow(clippy::too_many_arguments, clippy::missing_errors_doc)]
+    fn cross_validate_with<E, P>(
+        self,
+        estimator: E,
+        params: P,
+        x: &InputArray,
+        y: &OutputArray,
+        settings: &Settings,
+        kfold: &KFold,
+        metric: fn(&OutputArray, &OutputArray) -> f64,
+    ) -> Result<(CrossValidationResult, Self), Failed>
+    where
+        Self: Sized,
+        E: SupervisedEstimator<InputArray, OutputArray, P>,
+        P: Clone,
+    {
+        let result =
+            smartcore::model_selection::cross_validate(estimator, x, y, params, kfold, &metric)?;
+        let model = self.fit_inner(x, y, settings)?;
+        Ok((result, model))
+    }
+
+    /// Convenience wrapper around [`fit_inner`].
+    #[allow(clippy::missing_errors_doc)]
+    fn fit(self, x: &InputArray, y: &OutputArray, settings: &Settings) -> Result<Self, Failed>
+    where
+        Self: Sized,
+    {
+        self.fit_inner(x, y, settings)
+    }
+}

--- a/src/model/clustering.rs
+++ b/src/model/clustering.rs
@@ -76,8 +76,14 @@ where
     ///
     /// # Arguments
     /// * `truth` - Ground truth cluster labels.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the model has not been trained.
     pub fn evaluate(&mut self, truth: &ClusterArray) {
-        let predicted = self.predict(&self.x_train);
+        let predicted = self
+            .predict(&self.x_train)
+            .expect("model must be trained before evaluation");
         let mut scores = ClusterMetrics::<CLUSTER>::hcv_score();
         scores.compute(truth, &predicted);
         self.metrics = Some(scores);

--- a/src/model/regression.rs
+++ b/src/model/regression.rs
@@ -95,9 +95,9 @@ where
     pub fn predict(self, x: InputArray) -> Result<OutputArray, Failed> {
         let x = self
             .preprocessor
-            .preprocess(x, &self.settings.preprocessing)
+            .preprocess(x, &self.settings.supervised.preprocessing)
             .map_err(|_| Failed::transform("Cannot preprocess features"))?;
-        match self.settings.final_model_approach {
+        match self.settings.supervised.final_model_approach {
             FinalAlgorithm::None => Err(Failed::invalid_state("no final algorithm selected")),
             FinalAlgorithm::Best => {
                 let alg = self
@@ -144,8 +144,10 @@ where
     /// Returns an error if preprocessing or model evaluation fails.
     pub fn train(&mut self) -> Result<(), Failed> {
         // Train any necessary preprocessing
-        self.preprocessor
-            .train(&self.x_train.clone(), &self.settings.preprocessing);
+        self.preprocessor.train(
+            &self.x_train.clone(),
+            &self.settings.supervised.preprocessing,
+        );
 
         // Iterate over variants in RegressionAlgorithm
         for alg in RegressionAlgorithm::all_algorithms(&self.settings) {
@@ -229,7 +231,7 @@ where
                 .partial_cmp(&b.result.mean_test_score())
                 .unwrap_or(Equal)
         });
-        if self.settings.sort_by == Metric::RSquared {
+        if self.settings.supervised.sort_by == Metric::RSquared {
             self.comparison.reverse();
         }
     }
@@ -254,8 +256,10 @@ where
         table.set_header(vec![
             Cell::new("Model").add_attribute(Attribute::Bold),
             Cell::new("Time").add_attribute(Attribute::Bold),
-            Cell::new(format!("Training {}", self.settings.sort_by)).add_attribute(Attribute::Bold),
-            Cell::new(format!("Testing {}", self.settings.sort_by)).add_attribute(Attribute::Bold),
+            Cell::new(format!("Training {}", self.settings.supervised.sort_by))
+                .add_attribute(Attribute::Bold),
+            Cell::new(format!("Testing {}", self.settings.supervised.sort_by))
+                .add_attribute(Attribute::Bold),
         ]);
         for model in &self.comparison {
             let mut row_vec = vec![];
@@ -282,8 +286,10 @@ where
         meta_table.apply_modifier(UTF8_SOLID_INNER_BORDERS);
         meta_table.set_header(vec![
             Cell::new("Meta Model").add_attribute(Attribute::Bold),
-            Cell::new(format!("Training {}", self.settings.sort_by)).add_attribute(Attribute::Bold),
-            Cell::new(format!("Testing {}", self.settings.sort_by)).add_attribute(Attribute::Bold),
+            Cell::new(format!("Training {}", self.settings.supervised.sort_by))
+                .add_attribute(Attribute::Bold),
+            Cell::new(format!("Testing {}", self.settings.supervised.sort_by))
+                .add_attribute(Attribute::Bold),
         ]);
 
         // Populate row

--- a/src/settings/classification_settings.rs
+++ b/src/settings/classification_settings.rs
@@ -1,6 +1,7 @@
 use super::{
     DecisionTreeClassifierParameters, FinalAlgorithm, KNNClassifierParameters,
     LogisticRegressionParameters, Metric, PreProcessing, RandomForestClassifierParameters,
+    SupervisedSettings,
 };
 use smartcore::linalg::basic::arrays::Array1;
 use smartcore::numbers::basenum::Number;
@@ -8,18 +9,8 @@ use smartcore::{metrics::accuracy, model_selection::KFold};
 
 /// Settings for classification models
 pub struct ClassificationSettings {
-    /// The metric to sort by
-    pub(crate) sort_by: Metric,
-    /// The number of folds for cross-validation
-    pub(crate) number_of_folds: usize,
-    /// Whether to shuffle the data
-    pub(crate) shuffle: bool,
-    /// Whether to be verbose
-    pub(crate) verbose: bool,
-    /// The approach to use for the final model
-    pub(crate) final_model_approach: FinalAlgorithm,
-    /// The kind of preprocessing to perform
-    pub(crate) preprocessing: PreProcessing,
+    /// Shared supervised settings
+    pub(crate) supervised: SupervisedSettings,
     /// Optional settings for KNN classifier
     pub(crate) knn_classifier_settings: Option<KNNClassifierParameters>,
     /// Optional settings for decision tree classifier
@@ -33,12 +24,10 @@ pub struct ClassificationSettings {
 impl Default for ClassificationSettings {
     fn default() -> Self {
         Self {
-            sort_by: Metric::Accuracy,
-            number_of_folds: 10,
-            shuffle: false,
-            verbose: false,
-            final_model_approach: FinalAlgorithm::Best,
-            preprocessing: PreProcessing::None,
+            supervised: SupervisedSettings {
+                sort_by: Metric::Accuracy,
+                ..SupervisedSettings::default()
+            },
             knn_classifier_settings: Some(KNNClassifierParameters::default()),
             decision_tree_classifier_settings: Some(DecisionTreeClassifierParameters::default()),
             random_forest_classifier_settings: Some(RandomForestClassifierParameters::default()),
@@ -50,9 +39,7 @@ impl Default for ClassificationSettings {
 impl ClassificationSettings {
     /// Get the k-fold cross-validator
     pub(crate) fn get_kfolds(&self) -> KFold {
-        KFold::default()
-            .with_n_splits(self.number_of_folds)
-            .with_shuffle(self.shuffle)
+        self.supervised.get_kfolds()
     }
 
     pub(crate) fn get_metric<OUTPUT, OutputArray>(&self) -> fn(&OutputArray, &OutputArray) -> f64
@@ -60,7 +47,7 @@ impl ClassificationSettings {
         OUTPUT: Number + Ord,
         OutputArray: Array1<OUTPUT>,
     {
-        match self.sort_by {
+        match self.supervised.sort_by {
             Metric::Accuracy => accuracy,
             Metric::None => panic!("A metric must be set."),
             _ => panic!("Unsupported metric for classification"),
@@ -70,35 +57,35 @@ impl ClassificationSettings {
     /// Specify number of folds for cross-validation
     #[must_use]
     pub const fn with_number_of_folds(mut self, n: usize) -> Self {
-        self.number_of_folds = n;
+        self.supervised = self.supervised.with_number_of_folds(n);
         self
     }
 
     /// Specify whether data should be shuffled
     #[must_use]
     pub const fn shuffle_data(mut self, shuffle: bool) -> Self {
-        self.shuffle = shuffle;
+        self.supervised = self.supervised.shuffle_data(shuffle);
         self
     }
 
     /// Specify whether to be verbose
     #[must_use]
     pub const fn verbose(mut self, verbose: bool) -> Self {
-        self.verbose = verbose;
+        self.supervised = self.supervised.verbose(verbose);
         self
     }
 
     /// Specify what type of preprocessing should be performed
     #[must_use]
     pub const fn with_preprocessing(mut self, pre: PreProcessing) -> Self {
-        self.preprocessing = pre;
+        self.supervised = self.supervised.with_preprocessing(pre);
         self
     }
 
     /// Specify what type of final model to use
     #[must_use]
     pub fn with_final_model(mut self, approach: FinalAlgorithm) -> Self {
-        self.final_model_approach = approach;
+        self.supervised = self.supervised.with_final_model(approach);
         self
     }
 

--- a/src/settings/common.rs
+++ b/src/settings/common.rs
@@ -1,0 +1,75 @@
+use super::{FinalAlgorithm, Metric, PreProcessing};
+use smartcore::model_selection::KFold;
+
+/// Settings shared by supervised learning models.
+pub struct SupervisedSettings {
+    pub(crate) sort_by: Metric,
+    pub(crate) number_of_folds: usize,
+    pub(crate) shuffle: bool,
+    pub(crate) verbose: bool,
+    pub(crate) final_model_approach: FinalAlgorithm,
+    pub(crate) preprocessing: PreProcessing,
+}
+
+impl Default for SupervisedSettings {
+    fn default() -> Self {
+        Self {
+            sort_by: Metric::Accuracy,
+            number_of_folds: 10,
+            shuffle: false,
+            verbose: false,
+            final_model_approach: FinalAlgorithm::Best,
+            preprocessing: PreProcessing::None,
+        }
+    }
+}
+
+impl SupervisedSettings {
+    pub(crate) fn get_kfolds(&self) -> KFold {
+        KFold::default()
+            .with_n_splits(self.number_of_folds)
+            .with_shuffle(self.shuffle)
+    }
+
+    #[must_use]
+    /// Set the number of folds for cross-validation.
+    pub const fn with_number_of_folds(mut self, n: usize) -> Self {
+        self.number_of_folds = n;
+        self
+    }
+
+    #[must_use]
+    /// Enable or disable shuffling of training data.
+    pub const fn shuffle_data(mut self, shuffle: bool) -> Self {
+        self.shuffle = shuffle;
+        self
+    }
+
+    #[must_use]
+    /// Enable or disable verbose logging.
+    pub const fn verbose(mut self, verbose: bool) -> Self {
+        self.verbose = verbose;
+        self
+    }
+
+    #[must_use]
+    /// Specify preprocessing strategy.
+    pub const fn with_preprocessing(mut self, pre: PreProcessing) -> Self {
+        self.preprocessing = pre;
+        self
+    }
+
+    #[must_use]
+    /// Choose the strategy for the final model.
+    pub fn with_final_model(mut self, approach: FinalAlgorithm) -> Self {
+        self.final_model_approach = approach;
+        self
+    }
+
+    #[must_use]
+    /// Set the metric used for sorting model results.
+    pub const fn sorted_by(mut self, sort_by: Metric) -> Self {
+        self.sort_by = sort_by;
+        self
+    }
+}

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -135,6 +135,9 @@ mod regression_settings;
 #[doc(no_inline)]
 pub use regression_settings::RegressionSettings;
 
+mod common;
+pub use common::SupervisedSettings;
+
 mod clustering_settings;
 pub use clustering_settings::{ClusteringAlgorithmName, ClusteringSettings};
 

--- a/tests/classification.rs
+++ b/tests/classification.rs
@@ -37,7 +37,7 @@ fn test_from_settings(settings: ClassificationSettings) {
     let (x, y) = classification_testing_data();
 
     let mut model = ClassificationModel::new(x, y, settings);
-    model.train();
+    model.train().unwrap();
 
     model
         .predict(DenseMatrix::from_2d_array(&[&[0.0, 0.0], &[1.0, 1.0]]).unwrap())


### PR DESCRIPTION
## Summary
- add SupervisedTrain trait encapsulating cross-validation and fitting
- introduce reusable SupervisedSettings and embed into classification/regression configs
- update models and docs for new training and settings APIs

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings -W clippy::pedantic`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b5a42e5788832584a4e113cfaa3edd