### PR TITLE
Unify KNN regressor variant

### DIFF
--- a/src/utils/distance.rs
+++ b/src/utils/distance.rs
@@ -2,6 +2,12 @@
 
 use std::fmt::{Display, Formatter};
 
+use smartcore::metrics::distance::{
+    Distance as SmartcoreDistance, euclidian::Euclidian, hamming::Hamming, manhattan::Manhattan,
+    minkowski::Minkowski,
+};
+use smartcore::numbers::basenum::Number;
+
 /// Distance metrics
 #[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum Distance {
@@ -29,6 +35,44 @@ impl Display for Distance {
             Self::Minkowski(n) => write!(f, "Minkowski(p = {n})"),
             Self::Mahalanobis => write!(f, "Mahalanobis"),
             Self::Hamming => write!(f, "Hamming"),
+        }
+    }
+}
+
+/// Wrapper implementing [`SmartcoreDistance`] for KNN regressors.
+#[derive(Clone)]
+pub enum KNNRegressorDistance<T: Number> {
+    /// Euclidean distance
+    Euclidean(Euclidian<T>),
+    /// Manhattan distance
+    Manhattan(Manhattan<T>),
+    /// Minkowski distance with parameter `p`
+    Minkowski(Minkowski<T>),
+    /// Hamming distance
+    Hamming(Hamming<T>),
+}
+
+impl<T: Number> SmartcoreDistance<Vec<T>> for KNNRegressorDistance<T> {
+    fn distance(&self, a: &Vec<T>, b: &Vec<T>) -> f64 {
+        match self {
+            Self::Euclidean(d) => d.distance(a, b),
+            Self::Manhattan(d) => d.distance(a, b),
+            Self::Minkowski(d) => d.distance(a, b),
+            Self::Hamming(d) => d.distance(a, b),
+        }
+    }
+}
+
+impl<T: Number> From<Distance> for KNNRegressorDistance<T> {
+    fn from(distance: Distance) -> Self {
+        match distance {
+            Distance::Euclidean => Self::Euclidean(Euclidian::new()),
+            Distance::Manhattan => Self::Manhattan(Manhattan::new()),
+            Distance::Minkowski(p) => Self::Minkowski(Minkowski::new(p)),
+            Distance::Hamming => Self::Hamming(Hamming::new()),
+            Distance::Mahalanobis => {
+                panic!("Mahalanobis distance is not supported for KNNRegressor")
+            }
         }
     }
 }

--- a/tests/algorithms.rs
+++ b/tests/algorithms.rs
@@ -16,18 +16,28 @@ fn all_algorithms_contains_linear() {
 }
 
 #[test]
-fn all_algorithms_respects_knn_distance() {
+fn all_algorithms_includes_knn_for_supported_distances() {
+    for distance in [
+        Distance::Euclidean,
+        Distance::Manhattan,
+        Distance::Minkowski(3),
+        Distance::Hamming,
+    ] {
+        let settings = RegressionSettings::default()
+            .with_knn_regressor_settings(KNNParameters::default().with_distance(distance));
+        let algorithms = Alg::all_algorithms(&settings);
+        assert!(algorithms.iter().any(|a| matches!(a, Alg::KNNRegressor(_))));
+    }
+}
+
+#[test]
+fn all_algorithms_skips_knn_for_mahalanobis() {
     let settings = RegressionSettings::default()
-        .with_knn_regressor_settings(KNNParameters::default().with_distance(Distance::Manhattan));
+        .with_knn_regressor_settings(KNNParameters::default().with_distance(Distance::Mahalanobis));
     let algorithms = Alg::all_algorithms(&settings);
     assert!(
         algorithms
             .iter()
-            .any(|a| matches!(a, Alg::KNNRegressorManhattan(_)))
-    );
-    assert!(
-        algorithms
-            .iter()
-            .all(|a| !matches!(a, Alg::KNNRegressorEuclidian(_)))
+            .all(|a| !matches!(a, Alg::KNNRegressor(_)))
     );
 }

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -2,6 +2,7 @@
 mod regression_data;
 
 use automl::algorithms::RegressionAlgorithm;
+use automl::settings::{Distance, KNNParameters};
 use automl::{DenseMatrix, RegressionSettings, SupervisedModel};
 use regression_data::regression_testing_data;
 
@@ -13,9 +14,17 @@ fn test_default_regression() {
 
 #[test]
 fn test_knn_only_regression() {
-    let settings =
-        RegressionSettings::default().only(&RegressionAlgorithm::default_knn_regressor());
-    test_from_settings(settings);
+    for distance in [
+        Distance::Euclidean,
+        Distance::Manhattan,
+        Distance::Minkowski(3),
+        Distance::Hamming,
+    ] {
+        let settings = RegressionSettings::default()
+            .with_knn_regressor_settings(KNNParameters::default().with_distance(distance))
+            .only(&RegressionAlgorithm::default_knn_regressor());
+        test_from_settings(settings);
+    }
 }
 
 fn test_from_settings(settings: RegressionSettings<f64, f64, DenseMatrix<f64>, Vec<f64>>) {


### PR DESCRIPTION
## Summary
- collapse multiple KNN regressor variants into a single distance-aware KNNRegressor
- add helper to build KNN parameters and remove distance-specific duplication
- expand regression tests to cover all KNN distances

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings -W clippy::pedantic`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b6165f8af083259fdcd537afd1014f