### PR TITLE
refactor: centralize supervised settings builders

### DIFF
--- a/examples/maximal_classification.rs
+++ b/examples/maximal_classification.rs
@@ -18,7 +18,7 @@ mod classification_data;
 use automl::settings::ClassificationSettings;
 use automl::settings::{
     DecisionTreeClassifierParameters, Distance, FinalAlgorithm, KNNAlgorithmName, KNNParameters,
-    KNNWeightFunction,
+    KNNWeightFunction, WithSupervisedSettings,
 };
 use automl::{ClassificationModel, DenseMatrix};
 use classification_data::classification_testing_data;

--- a/examples/maximal_regression.rs
+++ b/examples/maximal_regression.rs
@@ -23,6 +23,7 @@ use automl::{
         KNNAlgorithmName, KNNParameters, KNNWeightFunction, LassoParameters,
         LinearRegressionParameters, LinearRegressionSolverName, Metric,
         RandomForestRegressorParameters, RidgeRegressionParameters, RidgeRegressionSolverName,
+        WithSupervisedSettings,
     },
 };
 use regression_data::regression_testing_data;

--- a/examples/print_settings.rs
+++ b/examples/print_settings.rs
@@ -3,6 +3,7 @@ use automl::settings::{
     KNNParameters, KNNWeightFunction, LassoParameters, LinearRegressionParameters,
     LinearRegressionSolverName, Metric, PreProcessing, RandomForestRegressorParameters,
     RegressionSettings, RidgeRegressionParameters, RidgeRegressionSolverName,
+    WithSupervisedSettings,
 };
 use smartcore::linalg::basic::matrix::DenseMatrix;
 

--- a/src/algorithms/classification.rs
+++ b/src/algorithms/classification.rs
@@ -5,7 +5,7 @@ use std::time::Instant;
 
 use super::supervised_train::SupervisedTrain;
 use crate::model::{ComparisonEntry, supervised::Algorithm};
-use crate::settings::ClassificationSettings;
+use crate::settings::{ClassificationSettings, WithSupervisedSettings};
 use smartcore::api::SupervisedEstimator;
 use smartcore::error::Failed;
 use smartcore::linalg::basic::arrays::{Array1, Array2, MutArrayView1, MutArrayView2};

--- a/src/algorithms/regression.rs
+++ b/src/algorithms/regression.rs
@@ -6,7 +6,7 @@ use std::time::Instant;
 
 use super::supervised_train::SupervisedTrain;
 use crate::model::{ComparisonEntry, supervised::Algorithm};
-use crate::settings::RegressionSettings;
+use crate::settings::{RegressionSettings, WithSupervisedSettings};
 use crate::utils::distance::Distance;
 use smartcore::api::SupervisedEstimator;
 use smartcore::error::Failed;

--- a/src/settings/classification_settings.rs
+++ b/src/settings/classification_settings.rs
@@ -1,10 +1,10 @@
 use super::{
-    DecisionTreeClassifierParameters, FinalAlgorithm, KNNParameters, LogisticRegressionParameters,
-    Metric, PreProcessing, RandomForestClassifierParameters, SupervisedSettings,
+    DecisionTreeClassifierParameters, KNNParameters, LogisticRegressionParameters, Metric,
+    RandomForestClassifierParameters, SupervisedSettings, WithSupervisedSettings,
 };
 use smartcore::linalg::basic::arrays::Array1;
+use smartcore::metrics::accuracy;
 use smartcore::numbers::basenum::Number;
-use smartcore::{metrics::accuracy, model_selection::KFold};
 
 /// Settings for classification models
 pub struct ClassificationSettings {
@@ -36,11 +36,6 @@ impl Default for ClassificationSettings {
 }
 
 impl ClassificationSettings {
-    /// Get the k-fold cross-validator
-    pub(crate) fn get_kfolds(&self) -> KFold {
-        self.supervised.get_kfolds()
-    }
-
     pub(crate) fn get_metric<OUTPUT, OutputArray>(&self) -> fn(&OutputArray, &OutputArray) -> f64
     where
         OUTPUT: Number + Ord,
@@ -51,41 +46,6 @@ impl ClassificationSettings {
             Metric::None => panic!("A metric must be set."),
             _ => panic!("Unsupported metric for classification"),
         }
-    }
-
-    /// Specify number of folds for cross-validation
-    #[must_use]
-    pub const fn with_number_of_folds(mut self, n: usize) -> Self {
-        self.supervised = self.supervised.with_number_of_folds(n);
-        self
-    }
-
-    /// Specify whether data should be shuffled
-    #[must_use]
-    pub const fn shuffle_data(mut self, shuffle: bool) -> Self {
-        self.supervised = self.supervised.shuffle_data(shuffle);
-        self
-    }
-
-    /// Specify whether to be verbose
-    #[must_use]
-    pub const fn verbose(mut self, verbose: bool) -> Self {
-        self.supervised = self.supervised.verbose(verbose);
-        self
-    }
-
-    /// Specify what type of preprocessing should be performed
-    #[must_use]
-    pub const fn with_preprocessing(mut self, pre: PreProcessing) -> Self {
-        self.supervised = self.supervised.with_preprocessing(pre);
-        self
-    }
-
-    /// Specify what type of final model to use
-    #[must_use]
-    pub fn with_final_model(mut self, approach: FinalAlgorithm) -> Self {
-        self.supervised = self.supervised.with_final_model(approach);
-        self
     }
 
     /// Specify settings for KNN classifier
@@ -123,5 +83,15 @@ impl ClassificationSettings {
     ) -> Self {
         self.logistic_regression_settings = Some(settings);
         self
+    }
+}
+
+impl WithSupervisedSettings for ClassificationSettings {
+    fn supervised(&self) -> &SupervisedSettings {
+        &self.supervised
+    }
+
+    fn supervised_mut(&mut self) -> &mut SupervisedSettings {
+        &mut self.supervised
     }
 }

--- a/src/settings/common.rs
+++ b/src/settings/common.rs
@@ -1,5 +1,6 @@
 use super::{FinalAlgorithm, Metric, PreProcessing};
 use smartcore::model_selection::KFold;
+use std::mem;
 
 /// Settings shared by supervised learning models.
 pub struct SupervisedSettings {
@@ -71,5 +72,85 @@ impl SupervisedSettings {
     pub const fn sorted_by(mut self, sort_by: Metric) -> Self {
         self.sort_by = sort_by;
         self
+    }
+}
+
+/// Trait exposing builders that delegate to [`SupervisedSettings`].
+pub trait WithSupervisedSettings {
+    /// Immutable access to inner [`SupervisedSettings`].
+    fn supervised(&self) -> &SupervisedSettings;
+
+    /// Mutable access to inner [`SupervisedSettings`].
+    fn supervised_mut(&mut self) -> &mut SupervisedSettings;
+
+    /// Delegate builder for [`SupervisedSettings::with_number_of_folds`].
+    #[must_use]
+    fn with_number_of_folds(mut self, n: usize) -> Self
+    where
+        Self: Sized,
+    {
+        let settings = self.supervised_mut();
+        *settings = mem::take(settings).with_number_of_folds(n);
+        self
+    }
+
+    /// Delegate builder for [`SupervisedSettings::shuffle_data`].
+    #[must_use]
+    fn shuffle_data(mut self, shuffle: bool) -> Self
+    where
+        Self: Sized,
+    {
+        let settings = self.supervised_mut();
+        *settings = mem::take(settings).shuffle_data(shuffle);
+        self
+    }
+
+    /// Delegate builder for [`SupervisedSettings::verbose`].
+    #[must_use]
+    fn verbose(mut self, verbose: bool) -> Self
+    where
+        Self: Sized,
+    {
+        let settings = self.supervised_mut();
+        *settings = mem::take(settings).verbose(verbose);
+        self
+    }
+
+    /// Delegate builder for [`SupervisedSettings::with_preprocessing`].
+    #[must_use]
+    fn with_preprocessing(mut self, pre: PreProcessing) -> Self
+    where
+        Self: Sized,
+    {
+        let settings = self.supervised_mut();
+        *settings = mem::take(settings).with_preprocessing(pre);
+        self
+    }
+
+    /// Delegate builder for [`SupervisedSettings::with_final_model`].
+    #[must_use]
+    fn with_final_model(mut self, approach: FinalAlgorithm) -> Self
+    where
+        Self: Sized,
+    {
+        let settings = self.supervised_mut();
+        *settings = mem::take(settings).with_final_model(approach);
+        self
+    }
+
+    /// Delegate builder for [`SupervisedSettings::sorted_by`].
+    #[must_use]
+    fn sorted_by(mut self, sort_by: Metric) -> Self
+    where
+        Self: Sized,
+    {
+        let settings = self.supervised_mut();
+        *settings = mem::take(settings).sorted_by(sort_by);
+        self
+    }
+
+    /// Delegate to [`SupervisedSettings::get_kfolds`].
+    fn get_kfolds(&self) -> KFold {
+        self.supervised().get_kfolds()
     }
 }

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -10,7 +10,7 @@
 //!         KNNParameters, KNNWeightFunction, Kernel, LassoParameters,
 //!         LinearRegressionParameters, LinearRegressionSolverName, Metric,
 //!         RandomForestRegressorParameters, RidgeRegressionParameters, RidgeRegressionSolverName,
-//!         SVRParameters,
+//!         SVRParameters, WithSupervisedSettings,
 //!     },
 //! };
 //!
@@ -138,7 +138,7 @@ mod regression_settings;
 pub use regression_settings::RegressionSettings;
 
 mod common;
-pub use common::SupervisedSettings;
+pub use common::{SupervisedSettings, WithSupervisedSettings};
 
 mod clustering_settings;
 pub use clustering_settings::{ClusteringAlgorithmName, ClusteringSettings};

--- a/tests/classification.rs
+++ b/tests/classification.rs
@@ -2,7 +2,9 @@
 mod classification_data;
 
 use automl::algorithms::ClassificationAlgorithm;
-use automl::settings::{ClassificationSettings, RandomForestClassifierParameters};
+use automl::settings::{
+    ClassificationSettings, RandomForestClassifierParameters, WithSupervisedSettings,
+};
 use automl::{DenseMatrix, ModelError, SupervisedModel};
 use classification_data::classification_testing_data;
 

--- a/tests/supervised_settings.rs
+++ b/tests/supervised_settings.rs
@@ -1,0 +1,25 @@
+use automl::DenseMatrix;
+use automl::settings::{
+    ClassificationSettings, Metric, RegressionSettings, WithSupervisedSettings,
+};
+
+#[test]
+fn classification_builder_delegates() {
+    let settings = ClassificationSettings::default()
+        .with_number_of_folds(5)
+        .shuffle_data(true);
+    let kfold = settings.get_kfolds();
+    assert_eq!(kfold.n_splits, 5);
+    assert!(kfold.shuffle);
+}
+
+#[test]
+fn regression_builder_delegates() {
+    let settings = RegressionSettings::<f64, f64, DenseMatrix<f64>, Vec<f64>>::default()
+        .with_number_of_folds(4)
+        .shuffle_data(false)
+        .sorted_by(Metric::MeanAbsoluteError);
+    let kfold = settings.get_kfolds();
+    assert_eq!(kfold.n_splits, 4);
+    assert!(!kfold.shuffle);
+}


### PR DESCRIPTION
## Summary
- add `WithSupervisedSettings` trait to provide shared builder methods
- implement trait for classification and regression settings, removing duplicate builders
- test delegated builder behavior for supervised settings

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings -D clippy::pedantic`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b6169fc808832599a3eeb73ae6b5b4