### PR TITLE
feat(settings): add macro for builder methods

### DIFF
--- a/src/algorithms/regression.rs
+++ b/src/algorithms/regression.rs
@@ -6,8 +6,9 @@ use std::time::Instant;
 
 use super::supervised_train::SupervisedTrain;
 use crate::model::{ComparisonEntry, supervised::Algorithm};
+use crate::settings::WithSupervisedSettings;
+use crate::settings::{KNNParameters, RegressionSettings};
 use crate::utils::distance::{Distance, KNNRegressorDistance};
-use crate::settings::{KNNParameters, RegressionSettings, WithSupervisedSettings};
 use smartcore::api::SupervisedEstimator;
 use smartcore::error::Failed;
 use smartcore::linalg::basic::arrays::{Array1, Array2, MutArrayView1, MutArrayView2};

--- a/src/settings/classification_settings.rs
+++ b/src/settings/classification_settings.rs
@@ -2,6 +2,7 @@ use super::{
     DecisionTreeClassifierParameters, KNNParameters, LogisticRegressionParameters, Metric,
     RandomForestClassifierParameters, SupervisedSettings, WithSupervisedSettings,
 };
+use crate::settings::macros::with_settings_methods;
 use smartcore::linalg::basic::arrays::Array1;
 use smartcore::metrics::accuracy;
 use smartcore::numbers::basenum::Number;
@@ -48,41 +49,15 @@ impl ClassificationSettings {
         }
     }
 
-    /// Specify settings for KNN classifier
-    #[must_use]
-    pub const fn with_knn_classifier_settings(mut self, settings: KNNParameters) -> Self {
-        self.knn_classifier_settings = Some(settings);
-        self
-    }
-
-    /// Specify settings for decision tree classifier
-    #[must_use]
-    pub const fn with_decision_tree_classifier_settings(
-        mut self,
-        settings: DecisionTreeClassifierParameters,
-    ) -> Self {
-        self.decision_tree_classifier_settings = Some(settings);
-        self
-    }
-
-    /// Specify settings for random forest classifier
-    #[must_use]
-    pub const fn with_random_forest_classifier_settings(
-        mut self,
-        settings: RandomForestClassifierParameters,
-    ) -> Self {
-        self.random_forest_classifier_settings = Some(settings);
-        self
-    }
-
-    /// Specify settings for logistic regression classifier
-    #[must_use]
-    pub const fn with_logistic_regression_settings(
-        mut self,
-        settings: LogisticRegressionParameters<f64>,
-    ) -> Self {
-        self.logistic_regression_settings = Some(settings);
-        self
+    with_settings_methods! {
+        /// Specify settings for KNN classifier
+        with_knn_classifier_settings, knn_classifier_settings, KNNParameters;
+        /// Specify settings for decision tree classifier
+        with_decision_tree_classifier_settings, decision_tree_classifier_settings, DecisionTreeClassifierParameters;
+        /// Specify settings for random forest classifier
+        with_random_forest_classifier_settings, random_forest_classifier_settings, RandomForestClassifierParameters;
+        /// Specify settings for logistic regression classifier
+        with_logistic_regression_settings, logistic_regression_settings, LogisticRegressionParameters<f64>;
     }
 }
 

--- a/src/settings/macros.rs
+++ b/src/settings/macros.rs
@@ -1,0 +1,20 @@
+/// Macros for generating `with_*_settings` builder methods.
+macro_rules! with_settings_methods {
+    (
+        $(
+            $(#[$meta:meta])*
+            $with_fn:ident, $field:ident, $ty:ty
+        );* $(;)?
+    ) => {
+        $(
+            $(#[$meta])*
+            #[must_use]
+            pub const fn $with_fn(mut self, settings: $ty) -> Self {
+                self.$field = Some(settings);
+                self
+            }
+        )*
+    };
+}
+
+pub(crate) use with_settings_methods;

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -116,6 +116,8 @@ pub use smartcore::linear::logistic_regression::LogisticRegressionSolverName;
 /// Parameters for decision tree classification (re-export from [Smartcore](https://docs.rs/smartcore/))
 pub use smartcore::tree::decision_tree_classifier::DecisionTreeClassifierParameters;
 
+pub(crate) mod macros;
+
 mod knn_parameters;
 pub use knn_parameters::KNNParameters;
 /// Backwards compatibility alias for KNN parameters used in regression

--- a/src/settings/regression_settings.rs
+++ b/src/settings/regression_settings.rs
@@ -8,6 +8,7 @@ use super::{
     SupervisedSettings, WithSupervisedSettings,
 };
 use crate::algorithms::RegressionAlgorithm;
+use crate::settings::macros::with_settings_methods;
 
 use smartcore::linalg::basic::arrays::Array1;
 use smartcore::linalg::traits::{
@@ -124,59 +125,21 @@ where
         self
     }
 
-    /// Specify settings for linear regression
-    #[must_use]
-    pub const fn with_linear_settings(mut self, settings: LinearRegressionParameters) -> Self {
-        self.linear_settings = Some(settings);
-        self
-    }
-
-    /// Specify settings for lasso regression
-    #[must_use]
-    pub const fn with_lasso_settings(mut self, settings: LassoParameters) -> Self {
-        self.lasso_settings = Some(settings);
-        self
-    }
-
-    /// Specify settings for ridge regression
-    #[must_use]
-    pub const fn with_ridge_settings(mut self, settings: RidgeRegressionParameters<INPUT>) -> Self {
-        self.ridge_settings = Some(settings);
-        self
-    }
-
-    /// Specify settings for elastic net
-    #[must_use]
-    pub const fn with_elastic_net_settings(mut self, settings: ElasticNetParameters) -> Self {
-        self.elastic_net_settings = Some(settings);
-        self
-    }
-
-    /// Specify settings for KNN regressor
-    #[must_use]
-    pub const fn with_knn_regressor_settings(mut self, settings: KNNParameters) -> Self {
-        self.knn_regressor_settings = Some(settings);
-        self
-    }
-
-    /// Specify settings for random forest regressor
-    #[must_use]
-    pub const fn with_random_forest_regressor_settings(
-        mut self,
-        settings: RandomForestRegressorParameters,
-    ) -> Self {
-        self.random_forest_regressor_settings = Some(settings);
-        self
-    }
-
-    /// Specify settings for decision tree regressor
-    #[must_use]
-    pub const fn with_decision_tree_regressor_settings(
-        mut self,
-        settings: DecisionTreeRegressorParameters,
-    ) -> Self {
-        self.decision_tree_regressor_settings = Some(settings);
-        self
+    with_settings_methods! {
+        /// Specify settings for linear regression
+        with_linear_settings, linear_settings, LinearRegressionParameters;
+        /// Specify settings for lasso regression
+        with_lasso_settings, lasso_settings, LassoParameters;
+        /// Specify settings for ridge regression
+        with_ridge_settings, ridge_settings, RidgeRegressionParameters<INPUT>;
+        /// Specify settings for elastic net
+        with_elastic_net_settings, elastic_net_settings, ElasticNetParameters;
+        /// Specify settings for KNN regressor
+        with_knn_regressor_settings, knn_regressor_settings, KNNParameters;
+        /// Specify settings for random forest regressor
+        with_random_forest_regressor_settings, random_forest_regressor_settings, RandomForestRegressorParameters;
+        /// Specify settings for decision tree regressor
+        with_decision_tree_regressor_settings, decision_tree_regressor_settings, DecisionTreeRegressorParameters;
     }
 }
 

--- a/tests/settings_display.rs
+++ b/tests/settings_display.rs
@@ -1,9 +1,15 @@
 use automl::algorithms::RegressionAlgorithm;
+use automl::settings::{
+    ClassificationSettings, DecisionTreeClassifierParameters, KNNParameters,
+    LinearRegressionParameters, LogisticRegressionParameters, RandomForestClassifierParameters,
+    RandomForestRegressorParameters, WithSupervisedSettings,
+};
 use automl::{DenseMatrix, RegressionSettings};
 
 #[test]
 fn display_reflects_skiplist() {
     let settings = RegressionSettings::<f64, f64, DenseMatrix<f64>, Vec<f64>>::default()
+        .with_linear_settings(LinearRegressionParameters::default())
         .skip(RegressionAlgorithm::default_random_forest());
     let output = format!("{settings}");
     assert!(output.contains("Regression settings"));
@@ -11,7 +17,20 @@ fn display_reflects_skiplist() {
 
 #[test]
 fn random_forest_section_labels_n_trees() {
-    let settings = RegressionSettings::<f64, f64, DenseMatrix<f64>, Vec<f64>>::default();
+    let settings = RegressionSettings::<f64, f64, DenseMatrix<f64>, Vec<f64>>::default()
+        .with_random_forest_regressor_settings(RandomForestRegressorParameters::default());
     let output = format!("{settings}");
     assert!(output.contains("Regression settings"));
+}
+
+#[test]
+fn classification_builder_methods_chain() {
+    let settings = ClassificationSettings::default()
+        .with_knn_classifier_settings(KNNParameters::default())
+        .with_decision_tree_classifier_settings(DecisionTreeClassifierParameters::default())
+        .with_random_forest_classifier_settings(RandomForestClassifierParameters::default())
+        .with_logistic_regression_settings(LogisticRegressionParameters::default())
+        .with_number_of_folds(2);
+    let folds = settings.get_kfolds();
+    assert_eq!(folds.n_splits, 2);
 }


### PR DESCRIPTION
## Summary
- add `with_settings_methods!` macro to generate `with_*_settings` builders
- apply macro in classification and regression settings
- exercise builder macros in settings tests
- remove duplicate settings import in regression algorithm

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings -D clippy::pedantic`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b61cf3eafc83258d2453b0ff9ed0db