### PR TITLE
fix: resolve documentation warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,13 +99,13 @@ println!("{model}");
 let _clusters: Vec<u8> = model.predict(&x).expect("prediction");
 ```
 
-Additional runnable examples are available in the [`examples/` directory](examples),
-including [`minimal_classification.rs`](examples/minimal_classification.rs),
-[`maximal_classification.rs`](examples/maximal_classification.rs),
-[`minimal_regression.rs`](examples/minimal_regression.rs),
-[`maximal_regression.rs`](examples/maximal_regression.rs),
-[`minimal_clustering.rs`](examples/minimal_clustering.rs), and
-[`maximal_clustering.rs`](examples/maximal_clustering.rs).
+Additional runnable examples are available in the [examples/ directory](https://github.com/cmccomb/rust-automl/tree/main/examples),
+including [minimal_classification.rs](https://github.com/cmccomb/rust-automl/blob/main/examples/minimal_classification.rs),
+[maximal_classification.rs](https://github.com/cmccomb/rust-automl/blob/main/examples/maximal_classification.rs),
+[minimal_regression.rs](https://github.com/cmccomb/rust-automl/blob/main/examples/minimal_regression.rs),
+[maximal_regression.rs](https://github.com/cmccomb/rust-automl/blob/main/examples/maximal_regression.rs),
+[minimal_clustering.rs](https://github.com/cmccomb/rust-automl/blob/main/examples/minimal_clustering.rs), and
+[maximal_clustering.rs](https://github.com/cmccomb/rust-automl/blob/main/examples/maximal_clustering.rs).
 
 Model comparison:
 

--- a/src/algorithms/regression.rs
+++ b/src/algorithms/regression.rs
@@ -6,8 +6,8 @@ use std::time::Instant;
 
 use super::supervised_train::SupervisedTrain;
 use crate::model::{ComparisonEntry, supervised::Algorithm};
+use crate::settings::RegressionSettings;
 use crate::settings::WithSupervisedSettings;
-use crate::settings::{KNNParameters, RegressionSettings};
 use crate::utils::distance::{Distance, KNNRegressorDistance};
 use smartcore::api::SupervisedEstimator;
 use smartcore::error::Failed;

--- a/src/algorithms/supervised_train.rs
+++ b/src/algorithms/supervised_train.rs
@@ -63,7 +63,7 @@ where
         Ok((result, model))
     }
 
-    /// Convenience wrapper around [`fit_inner`].
+    /// Convenience wrapper around [`Self::fit_inner`].
     #[allow(clippy::missing_errors_doc)]
     fn fit(self, x: &InputArray, y: &OutputArray, settings: &Settings) -> Result<Self, Failed>
     where

--- a/src/settings/common.rs
+++ b/src/settings/common.rs
@@ -149,7 +149,7 @@ pub trait WithSupervisedSettings {
         self
     }
 
-    /// Delegate to [`SupervisedSettings::get_kfolds`].
+    /// Delegate to `SupervisedSettings::get_kfolds`.
     fn get_kfolds(&self) -> KFold {
         self.supervised().get_kfolds()
     }


### PR DESCRIPTION
## Summary
- remove unused import and tidy regression algorithm imports
- fix broken intra-doc links in settings and training docs
- update README example links for rustdoc compatibility

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings -W clippy::pedantic`
- `cargo test`
- `cargo doc --no-deps`


------
https://chatgpt.com/codex/tasks/task_e_68b63d8f2368832590863cae139a25ab