### PR TITLE
Remove redundant EVDDecomposable bound

### DIFF
--- a/src/algorithms/classification.rs
+++ b/src/algorithms/classification.rs
@@ -32,7 +32,6 @@ where
         + QRDecomposable<INPUT>
         + SVDDecomposable<INPUT>
         + EVDDecomposable<INPUT>
-        + EVDDecomposable<INPUT>
         + CholeskyDecomposable<INPUT>,
     OutputArray: MutArrayView1<OUTPUT> + Sized + Clone + Array1<OUTPUT>,
 {


### PR DESCRIPTION
## Summary
- clean up `ClassificationAlgorithm` bounds by removing duplicated `EVDDecomposable`

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings -W clippy::pedantic`
- `cargo test --all-features`


------
https://chatgpt.com/codex/tasks/task_e_68b643bf3b588325bc0ef37d5a64697b