### PR TITLE
feat: expose inherent settings and algorithm methods

### DIFF
--- a/examples/maximal_classification.rs
+++ b/examples/maximal_classification.rs
@@ -18,7 +18,7 @@ mod classification_data;
 use automl::settings::ClassificationSettings;
 use automl::settings::{
     DecisionTreeClassifierParameters, Distance, FinalAlgorithm, KNNAlgorithmName, KNNParameters,
-    KNNWeightFunction, WithSupervisedSettings,
+    KNNWeightFunction,
 };
 use automl::{ClassificationModel, DenseMatrix};
 use classification_data::classification_testing_data;

--- a/examples/maximal_regression.rs
+++ b/examples/maximal_regression.rs
@@ -23,7 +23,6 @@ use automl::{
         KNNAlgorithmName, KNNParameters, KNNWeightFunction, LassoParameters,
         LinearRegressionParameters, LinearRegressionSolverName, Metric,
         RandomForestRegressorParameters, RidgeRegressionParameters, RidgeRegressionSolverName,
-        WithSupervisedSettings,
     },
 };
 use regression_data::regression_testing_data;

--- a/examples/print_settings.rs
+++ b/examples/print_settings.rs
@@ -3,7 +3,6 @@ use automl::settings::{
     KNNParameters, KNNWeightFunction, LassoParameters, LinearRegressionParameters,
     LinearRegressionSolverName, Metric, PreProcessing, RandomForestRegressorParameters,
     RegressionSettings, RidgeRegressionParameters, RidgeRegressionSolverName,
-    WithSupervisedSettings,
 };
 use smartcore::linalg::basic::matrix::DenseMatrix;
 

--- a/src/algorithms/classification.rs
+++ b/src/algorithms/classification.rs
@@ -5,7 +5,7 @@ use std::time::Instant;
 
 use super::supervised_train::SupervisedTrain;
 use crate::model::{ComparisonEntry, supervised::Algorithm};
-use crate::settings::{ClassificationSettings, WithSupervisedSettings};
+use crate::settings::ClassificationSettings;
 use crate::utils::distance::KNNRegressorDistance;
 use smartcore::api::SupervisedEstimator;
 use smartcore::error::{Failed, FailedError};
@@ -331,6 +331,48 @@ where
     pub fn all_algorithms(settings: &ClassificationSettings) -> Vec<Self> {
         <Self as Algorithm<ClassificationSettings>>::all_algorithms(settings)
     }
+
+    /// Fit the algorithm using the provided settings.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Failed`] if training is not successful.
+    #[allow(clippy::missing_errors_doc)]
+    pub fn fit(
+        self,
+        x: &InputArray,
+        y: &OutputArray,
+        settings: &ClassificationSettings,
+    ) -> Result<Self, Failed> {
+        <Self as SupervisedTrain<
+            INPUT,
+            OUTPUT,
+            InputArray,
+            OutputArray,
+            ClassificationSettings,
+        >>::fit(self, x, y, settings)
+    }
+
+    /// Perform cross-validation for the algorithm.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Failed`] if cross-validation fails.
+    #[allow(clippy::missing_errors_doc)]
+    pub fn cv(
+        self,
+        x: &InputArray,
+        y: &OutputArray,
+        settings: &ClassificationSettings,
+    ) -> Result<(CrossValidationResult, Self), Failed> {
+        <Self as SupervisedTrain<
+            INPUT,
+            OUTPUT,
+            InputArray,
+            OutputArray,
+            ClassificationSettings,
+        >>::cv(self, x, y, settings)
+    }
 }
 
 impl<INPUT, OUTPUT, InputArray, OutputArray> Algorithm<ClassificationSettings>
@@ -468,7 +510,6 @@ where
 mod tests {
     use super::{ClassificationAlgorithm, ClassificationSettings};
     use crate::DenseMatrix;
-    use crate::algorithms::supervised_train::SupervisedTrain;
     use smartcore::error::FailedError;
 
     #[test]

--- a/src/algorithms/regression.rs
+++ b/src/algorithms/regression.rs
@@ -7,7 +7,6 @@ use std::time::Instant;
 use super::supervised_train::SupervisedTrain;
 use crate::model::{ComparisonEntry, supervised::Algorithm};
 use crate::settings::RegressionSettings;
-use crate::settings::WithSupervisedSettings;
 use crate::utils::distance::{Distance, KNNRegressorDistance};
 use smartcore::api::SupervisedEstimator;
 use smartcore::error::{Failed, FailedError};
@@ -410,6 +409,48 @@ where
             settings,
         )
     }
+
+    /// Fit the algorithm using the provided settings.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Failed`] if training is not successful.
+    #[allow(clippy::missing_errors_doc)]
+    pub fn fit(
+        self,
+        x: &InputArray,
+        y: &OutputArray,
+        settings: &RegressionSettings<INPUT, OUTPUT, InputArray, OutputArray>,
+    ) -> Result<Self, Failed> {
+        <Self as SupervisedTrain<
+            INPUT,
+            OUTPUT,
+            InputArray,
+            OutputArray,
+            RegressionSettings<INPUT, OUTPUT, InputArray, OutputArray>,
+        >>::fit(self, x, y, settings)
+    }
+
+    /// Perform cross-validation for the algorithm.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Failed`] if cross-validation fails.
+    #[allow(clippy::missing_errors_doc)]
+    pub fn cv(
+        self,
+        x: &InputArray,
+        y: &OutputArray,
+        settings: &RegressionSettings<INPUT, OUTPUT, InputArray, OutputArray>,
+    ) -> Result<(CrossValidationResult, Self), Failed> {
+        <Self as SupervisedTrain<
+            INPUT,
+            OUTPUT,
+            InputArray,
+            OutputArray,
+            RegressionSettings<INPUT, OUTPUT, InputArray, OutputArray>,
+        >>::cv(self, x, y, settings)
+    }
 }
 
 impl<INPUT, OUTPUT, InputArray, OutputArray>
@@ -568,7 +609,6 @@ where
 mod tests {
     use super::{RegressionAlgorithm, RegressionSettings};
     use crate::DenseMatrix;
-    use crate::algorithms::supervised_train::SupervisedTrain;
     use smartcore::error::FailedError;
 
     #[test]

--- a/src/settings/classification_settings.rs
+++ b/src/settings/classification_settings.rs
@@ -1,10 +1,12 @@
 use super::{
-    DecisionTreeClassifierParameters, KNNParameters, LogisticRegressionParameters, Metric,
-    RandomForestClassifierParameters, SupervisedSettings, WithSupervisedSettings,
+    DecisionTreeClassifierParameters, FinalAlgorithm, KNNParameters, LogisticRegressionParameters,
+    Metric, PreProcessing, RandomForestClassifierParameters, SupervisedSettings,
+    WithSupervisedSettings,
 };
 use crate::settings::macros::with_settings_methods;
 use smartcore::linalg::basic::arrays::Array1;
 use smartcore::metrics::accuracy;
+use smartcore::model_selection::KFold;
 use smartcore::numbers::basenum::Number;
 
 /// Settings for classification models
@@ -58,6 +60,95 @@ impl ClassificationSettings {
         with_random_forest_classifier_settings, random_forest_classifier_settings, RandomForestClassifierParameters;
         /// Specify settings for logistic regression classifier
         with_logistic_regression_settings, logistic_regression_settings, LogisticRegressionParameters<f64>;
+    }
+
+    /// Set the number of folds for cross-validation.
+    ///
+    /// # Examples
+    /// ```
+    /// use automl::settings::ClassificationSettings;
+    /// let settings = ClassificationSettings::default().with_number_of_folds(5);
+    /// assert_eq!(settings.get_kfolds().n_splits, 5);
+    /// ```
+    #[must_use]
+    pub fn with_number_of_folds(self, n: usize) -> Self {
+        <Self as WithSupervisedSettings>::with_number_of_folds(self, n)
+    }
+
+    /// Enable or disable shuffling of training data.
+    ///
+    /// # Examples
+    /// ```
+    /// use automl::settings::ClassificationSettings;
+    /// let settings = ClassificationSettings::default().shuffle_data(true);
+    /// assert!(settings.get_kfolds().shuffle);
+    /// ```
+    #[must_use]
+    pub fn shuffle_data(self, shuffle: bool) -> Self {
+        <Self as WithSupervisedSettings>::shuffle_data(self, shuffle)
+    }
+
+    /// Enable or disable verbose logging.
+    ///
+    /// # Examples
+    /// ```
+    /// use automl::settings::ClassificationSettings;
+    /// let settings = ClassificationSettings::default().verbose(true);
+    /// ```
+    #[must_use]
+    pub fn verbose(self, verbose: bool) -> Self {
+        <Self as WithSupervisedSettings>::verbose(self, verbose)
+    }
+
+    /// Specify preprocessing strategy.
+    ///
+    /// # Examples
+    /// ```
+    /// use automl::settings::{ClassificationSettings, PreProcessing};
+    /// let settings = ClassificationSettings::default()
+    ///     .with_preprocessing(PreProcessing::AddInteractions);
+    /// ```
+    #[must_use]
+    pub fn with_preprocessing(self, pre: PreProcessing) -> Self {
+        <Self as WithSupervisedSettings>::with_preprocessing(self, pre)
+    }
+
+    /// Choose the strategy for the final model.
+    ///
+    /// # Examples
+    /// ```
+    /// use automl::settings::{ClassificationSettings, FinalAlgorithm};
+    /// let settings = ClassificationSettings::default()
+    ///     .with_final_model(FinalAlgorithm::Best);
+    /// ```
+    #[must_use]
+    pub fn with_final_model(self, approach: FinalAlgorithm) -> Self {
+        <Self as WithSupervisedSettings>::with_final_model(self, approach)
+    }
+
+    /// Set the metric used for sorting model results.
+    ///
+    /// # Examples
+    /// ```
+    /// use automl::settings::{ClassificationSettings, Metric};
+    /// let settings = ClassificationSettings::default().sorted_by(Metric::Accuracy);
+    /// ```
+    #[must_use]
+    pub fn sorted_by(self, sort_by: Metric) -> Self {
+        <Self as WithSupervisedSettings>::sorted_by(self, sort_by)
+    }
+
+    /// Create a [`KFold`] configuration from these settings.
+    ///
+    /// # Examples
+    /// ```
+    /// use automl::settings::ClassificationSettings;
+    /// let folds = ClassificationSettings::default().get_kfolds();
+    /// assert_eq!(folds.n_splits, 10);
+    /// ```
+    #[must_use]
+    pub fn get_kfolds(&self) -> KFold {
+        <Self as WithSupervisedSettings>::get_kfolds(self)
     }
 }
 

--- a/src/settings/regression_settings.rs
+++ b/src/settings/regression_settings.rs
@@ -3,9 +3,10 @@
 #![allow(clippy::struct_field_names)]
 
 use super::{
-    DecisionTreeRegressorParameters, ElasticNetParameters, KNNParameters, LassoParameters,
-    LinearRegressionParameters, Metric, RandomForestRegressorParameters, RidgeRegressionParameters,
-    SupervisedSettings, WithSupervisedSettings,
+    DecisionTreeRegressorParameters, ElasticNetParameters, FinalAlgorithm, KNNParameters,
+    LassoParameters, LinearRegressionParameters, Metric, PreProcessing,
+    RandomForestRegressorParameters, RidgeRegressionParameters, SupervisedSettings,
+    WithSupervisedSettings,
 };
 use crate::algorithms::RegressionAlgorithm;
 use crate::settings::macros::with_settings_methods;
@@ -15,6 +16,7 @@ use smartcore::linalg::traits::{
     cholesky::CholeskyDecomposable, evd::EVDDecomposable, qr::QRDecomposable, svd::SVDDecomposable,
 };
 use smartcore::metrics::{mean_absolute_error, mean_squared_error, r2};
+use smartcore::model_selection::KFold;
 use smartcore::numbers::{basenum::Number, floatnum::FloatNumber, realnum::RealNumber};
 use std::fmt::{Display, Formatter};
 
@@ -140,6 +142,107 @@ where
         with_random_forest_regressor_settings, random_forest_regressor_settings, RandomForestRegressorParameters;
         /// Specify settings for decision tree regressor
         with_decision_tree_regressor_settings, decision_tree_regressor_settings, DecisionTreeRegressorParameters;
+    }
+
+    /// Set the number of folds for cross-validation.
+    ///
+    /// # Examples
+    /// ```
+    /// use automl::settings::RegressionSettings;
+    /// use automl::DenseMatrix;
+    /// let settings = RegressionSettings::<f64, f64, DenseMatrix<f64>, Vec<f64>>::default()
+    ///     .with_number_of_folds(5);
+    /// assert_eq!(settings.get_kfolds().n_splits, 5);
+    /// ```
+    #[must_use]
+    pub fn with_number_of_folds(self, n: usize) -> Self {
+        <Self as WithSupervisedSettings>::with_number_of_folds(self, n)
+    }
+
+    /// Enable or disable shuffling of training data.
+    ///
+    /// # Examples
+    /// ```
+    /// use automl::settings::RegressionSettings;
+    /// use automl::DenseMatrix;
+    /// let settings = RegressionSettings::<f64, f64, DenseMatrix<f64>, Vec<f64>>::default()
+    ///     .shuffle_data(true);
+    /// assert!(settings.get_kfolds().shuffle);
+    /// ```
+    #[must_use]
+    pub fn shuffle_data(self, shuffle: bool) -> Self {
+        <Self as WithSupervisedSettings>::shuffle_data(self, shuffle)
+    }
+
+    /// Enable or disable verbose logging.
+    ///
+    /// # Examples
+    /// ```
+    /// use automl::settings::RegressionSettings;
+    /// use automl::DenseMatrix;
+    /// let settings = RegressionSettings::<f64, f64, DenseMatrix<f64>, Vec<f64>>::default()
+    ///     .verbose(true);
+    /// ```
+    #[must_use]
+    pub fn verbose(self, verbose: bool) -> Self {
+        <Self as WithSupervisedSettings>::verbose(self, verbose)
+    }
+
+    /// Specify preprocessing strategy.
+    ///
+    /// # Examples
+    /// ```
+    /// use automl::settings::{PreProcessing, RegressionSettings};
+    /// use automl::DenseMatrix;
+    /// let settings = RegressionSettings::<f64, f64, DenseMatrix<f64>, Vec<f64>>::default()
+    ///     .with_preprocessing(PreProcessing::AddInteractions);
+    /// ```
+    #[must_use]
+    pub fn with_preprocessing(self, pre: PreProcessing) -> Self {
+        <Self as WithSupervisedSettings>::with_preprocessing(self, pre)
+    }
+
+    /// Choose the strategy for the final model.
+    ///
+    /// # Examples
+    /// ```
+    /// use automl::settings::{FinalAlgorithm, RegressionSettings};
+    /// use automl::DenseMatrix;
+    /// let settings = RegressionSettings::<f64, f64, DenseMatrix<f64>, Vec<f64>>::default()
+    ///     .with_final_model(FinalAlgorithm::Best);
+    /// ```
+    #[must_use]
+    pub fn with_final_model(self, approach: FinalAlgorithm) -> Self {
+        <Self as WithSupervisedSettings>::with_final_model(self, approach)
+    }
+
+    /// Set the metric used for sorting model results.
+    ///
+    /// # Examples
+    /// ```
+    /// use automl::settings::{Metric, RegressionSettings};
+    /// use automl::DenseMatrix;
+    /// let settings = RegressionSettings::<f64, f64, DenseMatrix<f64>, Vec<f64>>::default()
+    ///     .sorted_by(Metric::RSquared);
+    /// ```
+    #[must_use]
+    pub fn sorted_by(self, sort_by: Metric) -> Self {
+        <Self as WithSupervisedSettings>::sorted_by(self, sort_by)
+    }
+
+    /// Create a [`KFold`] configuration from these settings.
+    ///
+    /// # Examples
+    /// ```
+    /// use automl::settings::RegressionSettings;
+    /// use automl::DenseMatrix;
+    /// let folds = RegressionSettings::<f64, f64, DenseMatrix<f64>, Vec<f64>>::default()
+    ///     .get_kfolds();
+    /// assert_eq!(folds.n_splits, 10);
+    /// ```
+    #[must_use]
+    pub fn get_kfolds(&self) -> KFold {
+        <Self as WithSupervisedSettings>::get_kfolds(self)
     }
 }
 

--- a/tests/classification.rs
+++ b/tests/classification.rs
@@ -2,10 +2,7 @@
 mod classification_data;
 
 use automl::algorithms::ClassificationAlgorithm;
-use automl::algorithms::supervised_train::SupervisedTrain;
-use automl::settings::{
-    ClassificationSettings, RandomForestClassifierParameters, WithSupervisedSettings,
-};
+use automl::settings::{ClassificationSettings, RandomForestClassifierParameters};
 use automl::{DenseMatrix, ModelError, SupervisedModel};
 use classification_data::classification_testing_data;
 use smartcore::api::SupervisedEstimator;

--- a/tests/settings_display.rs
+++ b/tests/settings_display.rs
@@ -2,7 +2,7 @@ use automl::algorithms::RegressionAlgorithm;
 use automl::settings::{
     ClassificationSettings, DecisionTreeClassifierParameters, KNNParameters,
     LinearRegressionParameters, LogisticRegressionParameters, RandomForestClassifierParameters,
-    RandomForestRegressorParameters, WithSupervisedSettings,
+    RandomForestRegressorParameters,
 };
 use automl::{DenseMatrix, RegressionSettings};
 

--- a/tests/supervised_settings.rs
+++ b/tests/supervised_settings.rs
@@ -1,7 +1,5 @@
 use automl::DenseMatrix;
-use automl::settings::{
-    ClassificationSettings, Metric, RegressionSettings, WithSupervisedSettings,
-};
+use automl::settings::{ClassificationSettings, Metric, RegressionSettings};
 
 #[test]
 fn classification_builder_delegates() {


### PR DESCRIPTION
## Summary
- expose supervised settings builders as inherent methods
- add inherent `fit`/`cv` wrappers for algorithm enums
- drop trait imports from examples and tests

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings -D clippy::pedantic`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b7a6f6390c8325bad01693f64c68a8