### PR TITLE
feat: replace panics with error types for metrics and distances

### DIFF
--- a/src/algorithms/supervised_train.rs
+++ b/src/algorithms/supervised_train.rs
@@ -3,6 +3,8 @@ use smartcore::error::Failed;
 use smartcore::linalg::basic::arrays::{Array1, Array2};
 use smartcore::model_selection::{CrossValidationResult, KFold};
 
+use crate::settings::SettingsError;
+
 /// Trait encapsulating shared training logic for supervised algorithms.
 pub trait SupervisedTrain<INPUT, OUTPUT, InputArray, OutputArray, Settings>
 where
@@ -38,7 +40,11 @@ where
         Self: Sized;
 
     /// Retrieve the metric function for evaluation.
-    fn metric(settings: &Settings) -> fn(&OutputArray, &OutputArray) -> f64;
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SettingsError`] if no suitable metric is configured.
+    fn metric(settings: &Settings) -> Result<fn(&OutputArray, &OutputArray) -> f64, SettingsError>;
 
     /// Shared implementation of cross-validation and fitting.
     #[allow(clippy::too_many_arguments, clippy::missing_errors_doc)]

--- a/src/settings/error.rs
+++ b/src/settings/error.rs
@@ -1,0 +1,25 @@
+//! Error types used by settings modules.
+
+use std::fmt::{Display, Formatter};
+
+use super::Metric;
+
+/// Errors related to model settings.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SettingsError {
+    /// A required metric was not specified.
+    MetricNotSet,
+    /// The provided metric is not supported for the task.
+    UnsupportedMetric(Metric),
+}
+
+impl Display for SettingsError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MetricNotSet => write!(f, "a metric must be set"),
+            Self::UnsupportedMetric(m) => write!(f, "unsupported metric: {m}"),
+        }
+    }
+}
+
+impl std::error::Error for SettingsError {}

--- a/src/settings/knn_parameters.rs
+++ b/src/settings/knn_parameters.rs
@@ -1,6 +1,6 @@
 //! KNN parameters
 
-use crate::utils::distance::{Distance, KNNRegressorDistance};
+use crate::utils::distance::{Distance, DistanceError, KNNRegressorDistance};
 use smartcore::numbers::{floatnum::FloatNumber, realnum::RealNumber};
 pub use smartcore::{algorithm::neighbour::KNNAlgorithmName, neighbors::KNNWeightFunction};
 
@@ -46,34 +46,50 @@ impl KNNParameters {
         self
     }
 
-    /// Convert to smartcore KNN classifier parameters using the configured distance metric
-    #[must_use]
+    /// Convert to smartcore KNN classifier parameters using the configured distance metric.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DistanceError::UnsupportedDistance`] if the configured distance is not supported.
     pub fn to_classifier_params<INPUT: RealNumber + FloatNumber>(
         &self,
-    ) -> smartcore::neighbors::knn_classifier::KNNClassifierParameters<
-        INPUT,
-        KNNRegressorDistance<INPUT>,
+    ) -> Result<
+        smartcore::neighbors::knn_classifier::KNNClassifierParameters<
+            INPUT,
+            KNNRegressorDistance<INPUT>,
+        >,
+        DistanceError,
     > {
-        smartcore::neighbors::knn_classifier::KNNClassifierParameters::default()
-            .with_k(self.k)
-            .with_algorithm(self.algorithm.clone())
-            .with_weight(self.weight.clone())
-            .with_distance(KNNRegressorDistance::from(self.distance))
+        Ok(
+            smartcore::neighbors::knn_classifier::KNNClassifierParameters::default()
+                .with_k(self.k)
+                .with_algorithm(self.algorithm.clone())
+                .with_weight(self.weight.clone())
+                .with_distance(KNNRegressorDistance::from(self.distance)?),
+        )
     }
 
-    /// Convert to smartcore KNN regressor parameters using the configured distance metric
-    #[must_use]
+    /// Convert to smartcore KNN regressor parameters using the configured distance metric.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DistanceError::UnsupportedDistance`] if the configured distance is not supported.
     pub fn to_regressor_params<INPUT: RealNumber + FloatNumber>(
         &self,
-    ) -> smartcore::neighbors::knn_regressor::KNNRegressorParameters<
-        INPUT,
-        KNNRegressorDistance<INPUT>,
+    ) -> Result<
+        smartcore::neighbors::knn_regressor::KNNRegressorParameters<
+            INPUT,
+            KNNRegressorDistance<INPUT>,
+        >,
+        DistanceError,
     > {
-        smartcore::neighbors::knn_regressor::KNNRegressorParameters::default()
-            .with_k(self.k)
-            .with_algorithm(self.algorithm.clone())
-            .with_weight(self.weight.clone())
-            .with_distance(KNNRegressorDistance::from(self.distance))
+        Ok(
+            smartcore::neighbors::knn_regressor::KNNRegressorParameters::default()
+                .with_k(self.k)
+                .with_algorithm(self.algorithm.clone())
+                .with_weight(self.weight.clone())
+                .with_distance(KNNRegressorDistance::from(self.distance)?),
+        )
     }
 }
 

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -147,9 +147,13 @@ pub use clustering_settings::{ClusteringAlgorithmName, ClusteringSettings};
 
 use std::fmt::{Display, Formatter};
 
+/// Error types for settings operations.
+pub mod error;
+pub use error::SettingsError;
+
 /// Metrics for evaluating algorithms
 #[non_exhaustive]
-#[derive(PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum Metric {
     /// Sort by R^2
     RSquared,
@@ -170,7 +174,7 @@ impl Display for Metric {
             Self::MeanAbsoluteError => write!(f, "MAE"),
             Self::MeanSquaredError => write!(f, "MSE"),
             Self::Accuracy => write!(f, "Accuracy"),
-            Self::None => panic!("A metric must be set."),
+            Self::None => write!(f, "None"),
         }
     }
 }

--- a/src/settings/regression_settings.rs
+++ b/src/settings/regression_settings.rs
@@ -5,7 +5,7 @@
 use super::{
     DecisionTreeRegressorParameters, ElasticNetParameters, FinalAlgorithm, KNNParameters,
     LassoParameters, LinearRegressionParameters, Metric, PreProcessing,
-    RandomForestRegressorParameters, RidgeRegressionParameters, SupervisedSettings,
+    RandomForestRegressorParameters, RidgeRegressionParameters, SettingsError, SupervisedSettings,
     WithSupervisedSettings,
 };
 use crate::algorithms::RegressionAlgorithm;
@@ -93,14 +93,18 @@ where
         + QRDecomposable<INPUT>,
     OutputArray: Array1<OUTPUT>,
 {
-    /// Get the metric function
-    pub(crate) fn get_metric(&self) -> fn(&OutputArray, &OutputArray) -> f64 {
+    /// Retrieve the metric function for regression tasks.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SettingsError`] if no metric is set or if the metric is unsupported.
+    pub fn get_metric(&self) -> Result<fn(&OutputArray, &OutputArray) -> f64, SettingsError> {
         match self.supervised.sort_by {
-            Metric::RSquared => r2,
-            Metric::MeanAbsoluteError => mean_absolute_error,
-            Metric::MeanSquaredError => mean_squared_error,
-            Metric::Accuracy => panic!("Accuracy metric not supported for regression"),
-            Metric::None => panic!("A metric must be set."),
+            Metric::RSquared => Ok(r2),
+            Metric::MeanAbsoluteError => Ok(mean_absolute_error),
+            Metric::MeanSquaredError => Ok(mean_squared_error),
+            Metric::Accuracy => Err(SettingsError::UnsupportedMetric(Metric::Accuracy)),
+            Metric::None => Err(SettingsError::MetricNotSet),
         }
     }
 

--- a/src/utils/distance/error.rs
+++ b/src/utils/distance/error.rs
@@ -1,0 +1,22 @@
+//! Error types for distance calculations.
+
+use std::fmt::{Display, Formatter};
+
+use super::Distance;
+
+/// Errors that can occur when working with distance metrics.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DistanceError {
+    /// Distance metric is not supported in this context.
+    UnsupportedDistance(Distance),
+}
+
+impl Display for DistanceError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnsupportedDistance(d) => write!(f, "unsupported distance: {d}"),
+        }
+    }
+}
+
+impl std::error::Error for DistanceError {}

--- a/tests/algorithms.rs
+++ b/tests/algorithms.rs
@@ -56,8 +56,8 @@ fn knn_param_conversion_matches_for_classifier_and_regressor() {
             .with_weight(KNNWeightFunction::Distance)
             .with_algorithm(KNNAlgorithmName::LinearSearch)
             .with_distance(distance);
-        let classifier = params.to_classifier_params::<f64>();
-        let regressor = params.to_regressor_params::<f64>();
+        let classifier = params.to_classifier_params::<f64>().unwrap();
+        let regressor = params.to_regressor_params::<f64>().unwrap();
 
         assert_eq!(classifier.k, regressor.k);
         assert_eq!(

--- a/tests/classification.rs
+++ b/tests/classification.rs
@@ -108,11 +108,7 @@ fn invalid_alpha_returns_error() {
     let result = algorithm.fit(&x, &y, &settings);
 
     // Assert
-    assert!(result.is_err());
-    let message = match result {
-        Ok(_) => panic!("expected training to fail"),
-        Err(err) => err.to_string(),
-    };
+    let message = result.err().unwrap().to_string();
     assert!(
         message.contains("alpha value must be finite"),
         "Unexpected error message: {message}"

--- a/tests/distance.rs
+++ b/tests/distance.rs
@@ -1,4 +1,5 @@
-use automl::utils::Distance;
+use automl::settings::KNNParameters;
+use automl::utils::distance::{Distance, DistanceError, KNNRegressorDistance};
 
 #[allow(clippy::clone_on_copy)]
 fn assert_traits(dist: Distance, display: &str, debug: &str) {
@@ -17,4 +18,26 @@ fn distance_trait_behaviors_and_display() {
     assert_traits(Distance::Minkowski(4), "Minkowski(p = 4)", "Minkowski(4)");
     assert_traits(Distance::Mahalanobis, "Mahalanobis", "Mahalanobis");
     assert_traits(Distance::Hamming, "Hamming", "Hamming");
+}
+
+#[test]
+fn knn_distance_from_mahalanobis_errors() {
+    let err = KNNRegressorDistance::<f64>::from(Distance::Mahalanobis).unwrap_err();
+    assert_eq!(
+        err,
+        DistanceError::UnsupportedDistance(Distance::Mahalanobis)
+    );
+}
+
+#[test]
+fn knn_param_conversion_mahalanobis_errors() {
+    let params = KNNParameters::default().with_distance(Distance::Mahalanobis);
+    assert!(matches!(
+        params.to_classifier_params::<f64>(),
+        Err(DistanceError::UnsupportedDistance(Distance::Mahalanobis))
+    ));
+    assert!(matches!(
+        params.to_regressor_params::<f64>(),
+        Err(DistanceError::UnsupportedDistance(Distance::Mahalanobis))
+    ));
 }

--- a/tests/settings_error.rs
+++ b/tests/settings_error.rs
@@ -1,0 +1,32 @@
+use automl::settings::{ClassificationSettings, Metric, SettingsError};
+use automl::{DenseMatrix, RegressionSettings};
+
+#[test]
+fn classification_metric_not_set_returns_error() {
+    let settings = ClassificationSettings::default().sorted_by(Metric::None);
+    let err = settings.get_metric::<u32, Vec<u32>>().unwrap_err();
+    assert_eq!(err, SettingsError::MetricNotSet);
+}
+
+#[test]
+fn classification_metric_unsupported_returns_error() {
+    let settings = ClassificationSettings::default().sorted_by(Metric::RSquared);
+    let err = settings.get_metric::<u32, Vec<u32>>().unwrap_err();
+    assert_eq!(err, SettingsError::UnsupportedMetric(Metric::RSquared));
+}
+
+#[test]
+fn regression_metric_not_set_returns_error() {
+    let settings = RegressionSettings::<f64, f64, DenseMatrix<f64>, Vec<f64>>::default()
+        .sorted_by(Metric::None);
+    let err = settings.get_metric().unwrap_err();
+    assert_eq!(err, SettingsError::MetricNotSet);
+}
+
+#[test]
+fn regression_metric_unsupported_returns_error() {
+    let settings = RegressionSettings::<f64, f64, DenseMatrix<f64>, Vec<f64>>::default()
+        .sorted_by(Metric::Accuracy);
+    let err = settings.get_metric().unwrap_err();
+    assert_eq!(err, SettingsError::UnsupportedMetric(Metric::Accuracy));
+}


### PR DESCRIPTION
## Summary
- introduce `SettingsError` and `DistanceError` enums and expose metric/distance helpers as `Result`
- update KNN parameter conversions and metric selection to return errors instead of panicking
- add tests for unsupported metrics and distances

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings -W clippy::pedantic`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68bb24fe25a083258ccb3f15ea0d1952