### PR TITLE
Add categorical Naive Bayes classifier support

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Model comparison:
 ## Capabilities
 - Feature Engineering: PCA, SVD, interaction terms, polynomial terms
 - Regression: Decision Tree, KNN, Random Forest, Linear, Ridge, LASSO, Elastic Net, Support Vector Regression
-- Classification: Random Forest, Decision Tree, KNN, Logistic Regression, Gaussian Naive Bayes
+- Classification: Random Forest, Decision Tree, KNN, Logistic Regression, Gaussian Naive Bayes, Categorical Naive Bayes
 - Clustering: K-Means, Agglomerative, DBSCAN
 - Meta-learning: Blending (experimental)
 - Persistence: Save/load settings and models

--- a/src/settings/classification_settings.rs
+++ b/src/settings/classification_settings.rs
@@ -1,7 +1,7 @@
 use super::{
-    DecisionTreeClassifierParameters, FinalAlgorithm, GaussianNBParameters, KNNParameters,
-    LogisticRegressionParameters, Metric, PreProcessing, RandomForestClassifierParameters,
-    SettingsError, SupervisedSettings, WithSupervisedSettings,
+    CategoricalNBParameters, DecisionTreeClassifierParameters, FinalAlgorithm,
+    GaussianNBParameters, KNNParameters, LogisticRegressionParameters, Metric, PreProcessing,
+    RandomForestClassifierParameters, SettingsError, SupervisedSettings, WithSupervisedSettings,
 };
 use crate::settings::macros::with_settings_methods;
 use smartcore::linalg::basic::arrays::Array1;
@@ -23,6 +23,8 @@ pub struct ClassificationSettings {
     pub(crate) logistic_regression_settings: Option<LogisticRegressionParameters<f64>>,
     /// Optional settings for Gaussian naive Bayes classifier
     pub(crate) gaussian_nb_settings: Option<GaussianNBParameters>,
+    /// Optional settings for categorical naive Bayes classifier
+    pub(crate) categorical_nb_settings: Option<CategoricalNBParameters>,
 }
 
 impl Default for ClassificationSettings {
@@ -37,6 +39,7 @@ impl Default for ClassificationSettings {
             random_forest_classifier_settings: Some(RandomForestClassifierParameters::default()),
             logistic_regression_settings: Some(LogisticRegressionParameters::default()),
             gaussian_nb_settings: Some(GaussianNBParameters::default()),
+            categorical_nb_settings: None,
         }
     }
 }
@@ -76,6 +79,13 @@ impl ClassificationSettings {
     #[must_use]
     pub fn with_gaussian_nb_settings(mut self, settings: GaussianNBParameters) -> Self {
         self.gaussian_nb_settings = Some(settings);
+        self
+    }
+
+    /// Specify settings for categorical naive Bayes classifier
+    #[must_use]
+    pub fn with_categorical_nb_settings(mut self, settings: CategoricalNBParameters) -> Self {
+        self.categorical_nb_settings = Some(settings);
         self
     }
 

--- a/tests/classification.rs
+++ b/tests/classification.rs
@@ -2,7 +2,9 @@
 mod classification_data;
 
 use automl::algorithms::ClassificationAlgorithm;
-use automl::settings::{ClassificationSettings, RandomForestClassifierParameters};
+use automl::settings::{
+    CategoricalNBParameters, ClassificationSettings, RandomForestClassifierParameters,
+};
 use automl::{DenseMatrix, ModelError, SupervisedModel};
 use classification_data::classification_testing_data;
 use smartcore::api::SupervisedEstimator;
@@ -37,6 +39,19 @@ fn test_all_algorithms_included() {
         algorithms
             .iter()
             .any(|a| matches!(a, ClassificationAlgorithm::GaussianNB(_)))
+    );
+}
+
+#[test]
+fn categorical_nb_algorithm_available_when_enabled() {
+    let settings = ClassificationSettings::default()
+        .with_categorical_nb_settings(CategoricalNBParameters::default());
+    let algorithms = <ClassificationAlgorithm<f64, u32, DenseMatrix<f64>, Vec<u32>> as
+        automl::model::Algorithm<ClassificationSettings>>::all_algorithms(&settings);
+    assert!(
+        algorithms
+            .iter()
+            .any(|a| matches!(a, ClassificationAlgorithm::CategoricalNB(_)))
     );
 }
 


### PR DESCRIPTION
## Summary
- add a categorical Naive Bayes variant with feature conversion, manual cross-validation, and prediction handling inside `ClassificationAlgorithm`
- wire the new classifier through `ClassificationSettings`, defaults, and algorithm discovery
- extend classification tests and documentation to cover enabling and validating categorical Naive Bayes

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68cc473cf6a88325a142e97b7bd6a6cc