### PR TITLE
Add support vector classifier configuration and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Model comparison:
 ## Capabilities
 - Feature Engineering: PCA, SVD, interaction terms, polynomial terms
 - Regression: Decision Tree, KNN, Random Forest, Linear, Ridge, LASSO, Elastic Net, Support Vector Regression
-- Classification: Random Forest, Decision Tree, KNN, Logistic Regression, Gaussian Naive Bayes, Categorical Naive Bayes, Multinomial Naive Bayes (non-negative integer features)
+- Classification: Random Forest, Decision Tree, KNN, Logistic Regression, Support Vector Classifier, Gaussian Naive Bayes, Categorical Naive Bayes, Multinomial Naive Bayes (non-negative integer features)
 - Clustering: K-Means, Agglomerative, DBSCAN
 - Meta-learning: Blending (experimental)
 - Persistence: Save/load settings and models

--- a/src/utils/kernels.rs
+++ b/src/utils/kernels.rs
@@ -2,6 +2,18 @@
 
 use std::fmt::{Display, Formatter};
 
+use smartcore::error::{Failed, FailedError};
+use smartcore::svm::Kernels as SmartcoreKernels;
+
+/// Smartcore kernel conversion result containing both the enum representation and a boxed kernel
+/// function suitable for Smartcore APIs.
+pub struct SmartcoreKernel {
+    /// Smartcore kernel enum configured with validated parameters.
+    pub kernel: SmartcoreKernels,
+    /// Boxed kernel function implementing [`smartcore::svm::Kernel`].
+    pub function: Box<dyn smartcore::svm::Kernel>,
+}
+
 /// Kernel options for use with support vector machines
 #[derive(serde::Serialize, serde::Deserialize)]
 pub enum Kernel {
@@ -31,5 +43,80 @@ impl Display for Kernel {
                 write!(f, "Sigmoid\n    gamma = {gamma}\n    coef = {coef}")
             }
         }
+    }
+}
+
+impl Kernel {
+    /// Convert the enum variant into Smartcore kernel components.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Failed`] when kernel parameters are invalid (for example, NaN or non-positive
+    /// values where Smartcore requires strictly positive parameters).
+    pub fn to_smartcore(&self) -> Result<SmartcoreKernel, Failed> {
+        match self {
+            Self::Linear => {
+                let kernel = SmartcoreKernels::linear();
+                Ok(SmartcoreKernel {
+                    function: Box::new(kernel.clone()),
+                    kernel,
+                })
+            }
+            Self::Polynomial(degree, gamma, coef0) => {
+                validate_positive(*degree, "polynomial degree")?;
+                validate_positive(*gamma, "polynomial gamma")?;
+                validate_finite(*coef0, "polynomial coef0")?;
+                let kernel = SmartcoreKernels::polynomial()
+                    .with_degree(*degree)
+                    .with_gamma(*gamma)
+                    .with_coef0(*coef0);
+                Ok(SmartcoreKernel {
+                    function: Box::new(kernel.clone()),
+                    kernel,
+                })
+            }
+            Self::RBF(gamma) => {
+                validate_positive(*gamma, "RBF gamma")?;
+                let kernel = SmartcoreKernels::rbf().with_gamma(*gamma);
+                Ok(SmartcoreKernel {
+                    function: Box::new(kernel.clone()),
+                    kernel,
+                })
+            }
+            Self::Sigmoid(gamma, coef0) => {
+                validate_finite(*gamma, "sigmoid gamma")?;
+                validate_finite(*coef0, "sigmoid coef0")?;
+                let kernel = SmartcoreKernels::sigmoid()
+                    .with_gamma(*gamma)
+                    .with_coef0(*coef0);
+                Ok(SmartcoreKernel {
+                    function: Box::new(kernel.clone()),
+                    kernel,
+                })
+            }
+        }
+    }
+}
+
+fn validate_finite(value: f64, name: &str) -> Result<(), Failed> {
+    if value.is_finite() {
+        Ok(())
+    } else {
+        Err(Failed::because(
+            FailedError::ParametersError,
+            &format!("{name} must be finite"),
+        ))
+    }
+}
+
+fn validate_positive(value: f64, name: &str) -> Result<(), Failed> {
+    validate_finite(value, name)?;
+    if value > 0.0 {
+        Ok(())
+    } else {
+        Err(Failed::because(
+            FailedError::ParametersError,
+            &format!("{name} must be positive"),
+        ))
     }
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -13,5 +13,5 @@ pub use self::display::{
 pub use self::distance::Distance;
 pub use self::features::{FeatureError, interaction_features, polynomial_features};
 pub use self::io::{CsvError, load_csv_features, load_labeled_csv};
-pub use self::kernels::Kernel;
+pub use self::kernels::{Kernel, SmartcoreKernel};
 pub use self::math::elementwise_multiply;


### PR DESCRIPTION
## Summary
- add optional Support Vector Classifier settings to classification configuration and serialization helpers
- convert kernel choices into Smartcore kernels and integrate SVC into the classification algorithm workflow
- document and test SVC enablement, training, prediction, and missing-setting error cases

## Testing
- `cargo fmt`
- `cargo clippy --all-targets --all-features -- -D warnings -D clippy::pedantic`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68cf1d4b8d6083258233b690a228b809