### PR TITLE
Add support vector regression integration and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,24 @@ let y = vec![1.0_f64, 2.0, 3.0];
 let _model = RegressionModel::new(x, y, RegressionSettings::default());
 ```
 
+Support Vector Regression can be enabled alongside the default algorithms and tuned with a
+kernel-specific configuration:
+
+```rust
+use automl::settings::{Kernel, SVRParameters};
+use automl::RegressionSettings;
+use smartcore::linalg::basic::matrix::DenseMatrix;
+
+let settings: RegressionSettings<f64, f64, DenseMatrix<f64>, Vec<f64>> =
+    RegressionSettings::default().with_svr_settings(
+    SVRParameters::default()
+        .with_eps(0.2)
+        .with_tol(1e-4)
+        .with_c(2.0)
+        .with_kernel(Kernel::RBF(0.4)),
+);
+```
+
 ### Loading data from CSV
 
 Use `load_labeled_csv` to read a dataset and separate the target column:

--- a/examples/maximal_regression.rs
+++ b/examples/maximal_regression.rs
@@ -20,9 +20,10 @@ use automl::{
     algorithms::RegressionAlgorithm,
     settings::{
         DecisionTreeRegressorParameters, Distance, ElasticNetParameters, FinalAlgorithm,
-        KNNAlgorithmName, KNNParameters, KNNWeightFunction, LassoParameters,
+        KNNAlgorithmName, KNNParameters, KNNWeightFunction, Kernel, LassoParameters,
         LinearRegressionParameters, LinearRegressionSolverName, Metric,
         RandomForestRegressorParameters, RidgeRegressionParameters, RidgeRegressionSolverName,
+        SVRParameters,
     },
 };
 use regression_data::regression_testing_data;
@@ -72,13 +73,13 @@ fn main() -> Result<(), Failed> {
                 .with_distance(Distance::Euclidean)
                 .with_weight(KNNWeightFunction::Uniform),
         )
-        // .with_svr_settings(
-        //     SVRParameters::default()
-        //         .with_eps(0.1)
-        //         .with_tol(1e-3)
-        //         .with_c(1.0)
-        //         .with_kernel(Kernel::Linear),
-        // )
+        .with_svr_settings(
+            SVRParameters::default()
+                .with_eps(0.05)
+                .with_tol(1e-4)
+                .with_c(2.5)
+                .with_kernel(Kernel::RBF(0.4)),
+        )
         .with_random_forest_regressor_settings(
             RandomForestRegressorParameters::default()
                 .with_m(1)

--- a/examples/print_settings.rs
+++ b/examples/print_settings.rs
@@ -1,8 +1,8 @@
 use automl::settings::{
     DecisionTreeRegressorParameters, Distance, ElasticNetParameters, KNNAlgorithmName,
-    KNNParameters, KNNWeightFunction, LassoParameters, LinearRegressionParameters,
+    KNNParameters, KNNWeightFunction, Kernel, LassoParameters, LinearRegressionParameters,
     LinearRegressionSolverName, Metric, PreProcessing, RandomForestRegressorParameters,
-    RegressionSettings, RidgeRegressionParameters, RidgeRegressionSolverName,
+    RegressionSettings, RidgeRegressionParameters, RidgeRegressionSolverName, SVRParameters,
 };
 use smartcore::linalg::basic::matrix::DenseMatrix;
 
@@ -45,13 +45,13 @@ fn main() {
                     .with_distance(Distance::Euclidean)
                     .with_weight(KNNWeightFunction::Uniform),
             )
-            // .with_svr_settings(
-            //     SVRParameters::default()
-            //         .with_eps(1e-10)
-            //         .with_tol(1e-10)
-            //         .with_c(1.0)
-            //         .with_kernel(Kernel::Linear),
-            // )
+            .with_svr_settings(
+                SVRParameters::default()
+                    .with_eps(0.1)
+                    .with_tol(1e-4)
+                    .with_c(1.5)
+                    .with_kernel(Kernel::Polynomial(2.0, 0.5, 1.0)),
+            )
             .with_random_forest_regressor_settings(
                 RandomForestRegressorParameters::default()
                     .with_m(100)

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -51,6 +51,13 @@
 //!             .with_distance(Distance::Euclidean)
 //!             .with_weight(KNNWeightFunction::Uniform),
 //!     )
+//!     .with_svr_settings(
+//!         SVRParameters::default()
+//!             .with_eps(0.2)
+//!             .with_tol(1e-4)
+//!             .with_c(2.0)
+//!             .with_kernel(Kernel::RBF(0.5)),
+//!     )
 //!     .with_random_forest_regressor_settings(
 //!         RandomForestRegressorParameters::default()
 //!             .with_m(100)

--- a/src/settings/regression_settings.rs
+++ b/src/settings/regression_settings.rs
@@ -5,8 +5,8 @@
 use super::{
     DecisionTreeRegressorParameters, ElasticNetParameters, FinalAlgorithm, KNNParameters,
     LassoParameters, LinearRegressionParameters, Metric, PreProcessing,
-    RandomForestRegressorParameters, RidgeRegressionParameters, SettingsError, SupervisedSettings,
-    WithSupervisedSettings,
+    RandomForestRegressorParameters, RidgeRegressionParameters, SVRParameters, SettingsError,
+    SupervisedSettings, WithSupervisedSettings,
 };
 use crate::algorithms::RegressionAlgorithm;
 use crate::settings::macros::with_settings_methods;
@@ -25,13 +25,14 @@ use std::fmt::{Display, Formatter};
 /// Any algorithms in the `skiplist` member will be skipped during training.
 pub struct RegressionSettings<INPUT, OUTPUT, InputArray, OutputArray>
 where
-    INPUT: FloatNumber + RealNumber,
-    OUTPUT: FloatNumber,
+    INPUT: FloatNumber + RealNumber + 'static,
+    OUTPUT: FloatNumber + 'static,
     InputArray: CholeskyDecomposable<INPUT>
         + SVDDecomposable<INPUT>
         + EVDDecomposable<INPUT>
-        + QRDecomposable<INPUT>,
-    OutputArray: Array1<OUTPUT>,
+        + QRDecomposable<INPUT>
+        + 'static,
+    OutputArray: Array1<OUTPUT> + 'static,
 {
     /// Shared supervised settings
     pub(crate) supervised: SupervisedSettings,
@@ -51,18 +52,21 @@ where
     pub(crate) random_forest_regressor_settings: Option<RandomForestRegressorParameters>,
     /// Optional settings for KNN regressor
     pub(crate) knn_regressor_settings: Option<KNNParameters>,
+    /// Optional settings for support vector regressor
+    pub(crate) svr_settings: Option<SVRParameters>,
 }
 
 impl<INPUT, OUTPUT, InputArray, OutputArray> Default
     for RegressionSettings<INPUT, OUTPUT, InputArray, OutputArray>
 where
-    INPUT: FloatNumber + RealNumber,
-    OUTPUT: FloatNumber,
+    INPUT: FloatNumber + RealNumber + 'static,
+    OUTPUT: FloatNumber + 'static,
     InputArray: CholeskyDecomposable<INPUT>
         + SVDDecomposable<INPUT>
         + EVDDecomposable<INPUT>
-        + QRDecomposable<INPUT>,
-    OutputArray: Array1<OUTPUT>,
+        + QRDecomposable<INPUT>
+        + 'static,
+    OutputArray: Array1<OUTPUT> + 'static,
 {
     fn default() -> Self {
         Self {
@@ -78,6 +82,7 @@ where
             decision_tree_regressor_settings: Some(DecisionTreeRegressorParameters::default()),
             random_forest_regressor_settings: Some(RandomForestRegressorParameters::default()),
             knn_regressor_settings: Some(KNNParameters::default()),
+            svr_settings: Some(SVRParameters::default()),
         }
     }
 }
@@ -85,13 +90,14 @@ where
 impl<INPUT, OUTPUT, InputArray, OutputArray>
     RegressionSettings<INPUT, OUTPUT, InputArray, OutputArray>
 where
-    INPUT: FloatNumber + RealNumber + Number,
-    OUTPUT: FloatNumber + Number,
+    INPUT: FloatNumber + RealNumber + Number + 'static,
+    OUTPUT: FloatNumber + Number + 'static,
     InputArray: CholeskyDecomposable<INPUT>
         + SVDDecomposable<INPUT>
         + EVDDecomposable<INPUT>
-        + QRDecomposable<INPUT>,
-    OutputArray: Array1<OUTPUT>,
+        + QRDecomposable<INPUT>
+        + 'static,
+    OutputArray: Array1<OUTPUT> + 'static,
 {
     /// Retrieve the metric function for regression tasks.
     ///
@@ -146,6 +152,15 @@ where
         with_random_forest_regressor_settings, random_forest_regressor_settings, RandomForestRegressorParameters;
         /// Specify settings for decision tree regressor
         with_decision_tree_regressor_settings, decision_tree_regressor_settings, DecisionTreeRegressorParameters;
+        /// Specify settings for support vector regressor
+        with_svr_settings, svr_settings, SVRParameters;
+    }
+
+    /// Disable the support vector regressor by removing its settings.
+    #[must_use]
+    pub fn without_svr_settings(mut self) -> Self {
+        self.svr_settings = None;
+        self
     }
 
     /// Set the number of folds for cross-validation.
@@ -253,13 +268,14 @@ where
 impl<INPUT, OUTPUT, InputArray, OutputArray> WithSupervisedSettings
     for RegressionSettings<INPUT, OUTPUT, InputArray, OutputArray>
 where
-    INPUT: FloatNumber + RealNumber,
-    OUTPUT: FloatNumber,
+    INPUT: FloatNumber + RealNumber + 'static,
+    OUTPUT: FloatNumber + 'static,
     InputArray: CholeskyDecomposable<INPUT>
         + SVDDecomposable<INPUT>
         + EVDDecomposable<INPUT>
-        + QRDecomposable<INPUT>,
-    OutputArray: Array1<OUTPUT>,
+        + QRDecomposable<INPUT>
+        + 'static,
+    OutputArray: Array1<OUTPUT> + 'static,
 {
     fn supervised(&self) -> &SupervisedSettings {
         &self.supervised
@@ -273,13 +289,14 @@ where
 impl<INPUT, OUTPUT, InputArray, OutputArray> Display
     for RegressionSettings<INPUT, OUTPUT, InputArray, OutputArray>
 where
-    INPUT: FloatNumber + RealNumber,
-    OUTPUT: FloatNumber,
+    INPUT: FloatNumber + RealNumber + 'static,
+    OUTPUT: FloatNumber + 'static,
     InputArray: CholeskyDecomposable<INPUT>
         + SVDDecomposable<INPUT>
         + EVDDecomposable<INPUT>
-        + QRDecomposable<INPUT>,
-    OutputArray: Array1<OUTPUT>,
+        + QRDecomposable<INPUT>
+        + 'static,
+    OutputArray: Array1<OUTPUT> + 'static,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(


### PR DESCRIPTION
## Summary
- add SVR settings to the regression settings builder and default configuration
- integrate a support vector regressor variant with manual cross-validation and prediction handling
- extend examples, README, and regression tests to cover SVR kernels, skiplist behavior, and missing settings errors

## Testing
- cargo fmt
- cargo clippy --all-targets -- -D warnings -D clippy::pedantic
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68cf23f88fd483258e004bd1b085b357