### PR TITLE
Add Extra Trees regressor support

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,31 @@ let settings: RegressionSettings<f64, f64, DenseMatrix<f64>, Vec<f64>> =
 );
 ```
 
+Extremely randomized trees offer another ensemble option that leans into randomness for lower
+variance models:
+
+```rust
+use automl::settings::ExtraTreesRegressorParameters;
+use automl::{DenseMatrix, RegressionSettings};
+
+let settings: RegressionSettings<f64, f64, DenseMatrix<f64>, Vec<f64>> =
+    RegressionSettings::default().with_extra_trees_settings(
+    ExtraTreesRegressorParameters::default()
+        .with_n_trees(50)
+        .with_min_samples_leaf(2)
+        .with_keep_samples(true)
+        .with_seed(7),
+);
+```
+
+Unlike the random forest regressor, the Extra Trees variant grows each tree on the full training
+set and samples split thresholds uniformly rather than optimizing them. The parameter
+`with_keep_samples(true)` is particularly useful here: because there is no bootstrapping, enabling
+it stores the original observations so that out-of-bag style diagnostics remain possible. You can
+also adjust `with_m(...)` to change how many random features are considered at each split—doing so
+directly influences the amount of randomness introduced by the split selection compared with the
+random forest estimator.
+
 ### Loading data from CSV
 
 Use `load_labeled_csv` to read a dataset and separate the target column:
@@ -172,7 +197,7 @@ Model comparison:
 
 ## Capabilities
 - Feature Engineering: PCA, SVD, interaction terms, polynomial terms
-- Regression: Decision Tree, KNN, Random Forest, Linear, Ridge, LASSO, Elastic Net, Support Vector Regression, `XGBoost` Gradient Boosting
+- Regression: Decision Tree, KNN, Random Forest, Extra Trees, Linear, Ridge, LASSO, Elastic Net, Support Vector Regression, `XGBoost` Gradient Boosting
 - Classification: Random Forest, Decision Tree, KNN, Logistic Regression, Support Vector Classifier, Gaussian Naive Bayes, Categorical Naive Bayes, Multinomial Naive Bayes (non-negative integer features)
 - Clustering: K-Means, Agglomerative, DBSCAN
 - Meta-learning: Blending (experimental)

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -81,6 +81,8 @@ pub use smartcore::neighbors::KNNWeightFunction;
 
 /// Search algorithms for k-nearest neighbor (KNN) regression (re-export from [Smartcore](https://docs.rs/smartcore/))
 pub use smartcore::algorithm::neighbour::KNNAlgorithmName;
+/// Parameters for extra trees regression (re-export from [Smartcore](https://docs.rs/smartcore/))
+pub use smartcore::ensemble::extra_trees_regressor::ExtraTreesRegressorParameters;
 /// Parameters for random forest regression (re-export from [Smartcore](https://docs.rs/smartcore/))
 pub use smartcore::ensemble::random_forest_regressor::RandomForestRegressorParameters;
 


### PR DESCRIPTION
## Summary
- re-export SmartCore's ExtraTreesRegressorParameters and expose builder/removal helpers in regression settings
- add an ExtraTreesRegressor algorithm variant with cross-validation, prediction, defaults, and skiplist support
- extend regression tests and documentation to cover the new ensemble option

## Testing
- cargo fmt
- cargo clippy --all-targets --all-features -- -D warnings -D clippy::pedantic
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68cf2d3afa188325bc23563921d9e494