### PR TITLE
Add Bernoulli naive Bayes classification support

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,23 @@ let settings = ClassificationSettings::default()
 If the feature matrix includes fractional or negative values, the Multinomial NB variant will
 emit a descriptive error explaining the constraint.
 
+Bernoulli Naive Bayes supports binary features and can also binarize continuous inputs when you
+provide a threshold. Set `binarize` to `None` to require pre-binarized inputs, or configure the
+threshold to map values above it to `1` and the rest to `0` during training and prediction:
+
+```rust
+use automl::settings::{BernoulliNBParameters, ClassificationSettings};
+
+let mut params = BernoulliNBParameters::default();
+params.binarize = None; // ensure features are already 0/1 encoded
+let settings = ClassificationSettings::default().with_bernoulli_nb_settings(params);
+
+// alternatively, binarize values greater than 0.5
+let thresholded = ClassificationSettings::default().with_bernoulli_nb_settings(
+    BernoulliNBParameters::default().with_binarize(0.5),
+);
+```
+
 ### Clustering
 ```rust
 use automl::ClusteringModel;
@@ -173,7 +190,7 @@ Model comparison:
 ## Capabilities
 - Feature Engineering: PCA, SVD, interaction terms, polynomial terms
 - Regression: Decision Tree, KNN, Random Forest, Linear, Ridge, LASSO, Elastic Net, Support Vector Regression, `XGBoost` Gradient Boosting
-- Classification: Random Forest, Decision Tree, KNN, Logistic Regression, Support Vector Classifier, Gaussian Naive Bayes, Categorical Naive Bayes, Multinomial Naive Bayes (non-negative integer features)
+- Classification: Random Forest, Decision Tree, KNN, Logistic Regression, Support Vector Classifier, Gaussian Naive Bayes, Bernoulli Naive Bayes (binary features or configurable thresholding), Categorical Naive Bayes, Multinomial Naive Bayes (non-negative integer features)
 - Clustering: K-Means, Agglomerative, DBSCAN
 - Meta-learning: Blending (experimental)
 - Persistence: Save/load settings and models

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -108,6 +108,9 @@ pub use smartcore::linear::ridge_regression::RidgeRegressionParameters;
 /// Solvers for ridge regression (re-export from [Smartcore](https://docs.rs/smartcore/))
 pub use smartcore::linear::ridge_regression::RidgeRegressionSolverName;
 
+/// Parameters for Bernoulli naive bayes (re-export from [Smartcore](https://docs.rs/smartcore/))
+pub use smartcore::naive_bayes::bernoulli::BernoulliNBParameters;
+
 /// Parameters for Gaussian naive bayes (re-export from [Smartcore](https://docs.rs/smartcore/))
 pub use smartcore::naive_bayes::gaussian::GaussianNBParameters;
 

--- a/tests/fixtures/classification_data.rs
+++ b/tests/fixtures/classification_data.rs
@@ -30,3 +30,38 @@ pub fn classification_testing_data() -> (DenseMatrix<f64>, Vec<u32>) {
 
     (x, y)
 }
+
+/// Return binary feature data for Bernoulli naive Bayes tests.
+///
+/// # Returns
+///
+/// * `(x, y)` - Feature matrix with binary entries and corresponding targets.
+#[cfg(test)]
+pub fn bernoulli_binary_classification_data() -> (DenseMatrix<f64>, Vec<u32>) {
+    let x = DenseMatrix::from_2d_array(&[
+        &[1.0, 0.0, 1.0],
+        &[0.0, 1.0, 0.0],
+        &[1.0, 1.0, 0.0],
+        &[0.0, 0.0, 1.0],
+    ])
+    .unwrap();
+
+    let y = vec![1, 0, 1, 0];
+
+    (x, y)
+}
+
+/// Return continuous feature data that can be binarized for Bernoulli naive Bayes tests.
+///
+/// # Returns
+///
+/// * `(x, y)` - Feature matrix and corresponding targets.
+#[cfg(test)]
+pub fn bernoulli_threshold_classification_data() -> (DenseMatrix<f64>, Vec<u32>) {
+    let x =
+        DenseMatrix::from_2d_array(&[&[0.2, 0.8], &[0.7, 0.3], &[0.9, 0.1], &[0.1, 0.9]]).unwrap();
+
+    let y = vec![1, 0, 0, 1];
+
+    (x, y)
+}


### PR DESCRIPTION
## Summary
- re-export Bernoulli NB settings and extend classification settings with a Bernoulli configuration toggle and serde support
- add Bernoulli NB preprocessing, training, cross-validation, and prediction handling alongside the existing classification algorithms
- expand classification fixtures/tests and README docs to cover Bernoulli NB usage, thresholding, and error handling

## Testing
- `cargo clippy --all-targets -- -D warnings -W clippy::pedantic`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68cf2d44f54c8325bb56e1664accb8f9