### PR TITLE
Add Bernoulli naive Bayes classification support

### DIFF
--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -81,6 +81,8 @@ pub use smartcore::neighbors::KNNWeightFunction;
 
 /// Search algorithms for k-nearest neighbor (KNN) regression (re-export from [Smartcore](https://docs.rs/smartcore/))
 pub use smartcore::algorithm::neighbour::KNNAlgorithmName;
+/// Parameters for extra trees regression (re-export from [Smartcore](https://docs.rs/smartcore/))
+pub use smartcore::ensemble::extra_trees_regressor::ExtraTreesRegressorParameters;
 /// Parameters for random forest regression (re-export from [Smartcore](https://docs.rs/smartcore/))
 pub use smartcore::ensemble::random_forest_regressor::RandomForestRegressorParameters;
 
@@ -107,6 +109,9 @@ pub use smartcore::linear::ridge_regression::RidgeRegressionParameters;
 
 /// Solvers for ridge regression (re-export from [Smartcore](https://docs.rs/smartcore/))
 pub use smartcore::linear::ridge_regression::RidgeRegressionSolverName;
+
+/// Parameters for Bernoulli naive bayes (re-export from [Smartcore](https://docs.rs/smartcore/))
+pub use smartcore::naive_bayes::bernoulli::BernoulliNBParameters;
 
 /// Parameters for Gaussian naive bayes (re-export from [Smartcore](https://docs.rs/smartcore/))
 pub use smartcore::naive_bayes::gaussian::GaussianNBParameters;

--- a/tests/fixtures/classification_data.rs
+++ b/tests/fixtures/classification_data.rs
@@ -30,3 +30,38 @@ pub fn classification_testing_data() -> (DenseMatrix<f64>, Vec<u32>) {
 
     (x, y)
 }
+
+/// Return binary feature data for Bernoulli naive Bayes tests.
+///
+/// # Returns
+///
+/// * `(x, y)` - Feature matrix with binary entries and corresponding targets.
+#[cfg(test)]
+pub fn bernoulli_binary_classification_data() -> (DenseMatrix<f64>, Vec<u32>) {
+    let x = DenseMatrix::from_2d_array(&[
+        &[1.0, 0.0, 1.0],
+        &[0.0, 1.0, 0.0],
+        &[1.0, 1.0, 0.0],
+        &[0.0, 0.0, 1.0],
+    ])
+    .unwrap();
+
+    let y = vec![1, 0, 1, 0];
+
+    (x, y)
+}
+
+/// Return continuous feature data that can be binarized for Bernoulli naive Bayes tests.
+///
+/// # Returns
+///
+/// * `(x, y)` - Feature matrix and corresponding targets.
+#[cfg(test)]
+pub fn bernoulli_threshold_classification_data() -> (DenseMatrix<f64>, Vec<u32>) {
+    let x =
+        DenseMatrix::from_2d_array(&[&[0.2, 0.8], &[0.7, 0.3], &[0.9, 0.1], &[0.1, 0.9]]).unwrap();
+
+    let y = vec![1, 0, 0, 1];
+
+    (x, y)
+}


### PR DESCRIPTION
## Summary
- re-export Bernoulli NB settings and extend classification settings with a Bernoulli configuration toggle and serde support
- add Bernoulli NB preprocessing, training, cross-validation, and prediction handling alongside the existing classification algorithms
- expand classification fixtures/tests and README docs to cover Bernoulli NB usage, thresholding, and error handling

## Testing
- `cargo clippy --all-targets -- -D warnings -W clippy::pedantic`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68cf2d44f54c8325bb56e1664accb8f9