### PR TITLE
Ensure minimal clustering example displays evaluation metrics

### DIFF
--- a/examples/minimal_clustering.rs
+++ b/examples/minimal_clustering.rs
@@ -25,6 +25,11 @@ fn main() {
     let mut model = ClusteringModel::new(x.clone(), settings);
     model.train();
 
+    // Evaluate clustering quality using the known ground-truth assignments
+    // for this fixture dataset.
+    let truth = vec![1_u8, 1, 2, 2];
+    model.evaluate(&truth);
+
     // Print trained results
     println!("{model}");
 

--- a/tests/clustering.rs
+++ b/tests/clustering.rs
@@ -5,6 +5,7 @@ use automl::{
     ClusteringModel, ModelError,
     metrics::ClusterMetrics,
     settings::{ClusteringAlgorithmName, ClusteringSettings},
+    utils::load_csv_features,
 };
 use clustering_data::clustering_testing_data;
 use smartcore::linalg::basic::matrix::DenseMatrix;
@@ -89,6 +90,23 @@ fn clustering_model_display_shows_metrics() {
     assert!(output.contains("Agglomerative"));
     assert!(output.contains("DBSCAN"));
     assert!(output.contains("V-Measure"));
+    assert!(output.contains("1.00"));
+}
+
+#[test]
+fn clustering_model_display_shows_metrics_for_fixture_csv() {
+    // Arrange
+    let x = load_csv_features("tests/fixtures/clustering_points.csv").unwrap();
+    let mut model: ClusteringModel<f64, u8, DenseMatrix<f64>, Vec<u8>> =
+        ClusteringModel::new(x.clone(), ClusteringSettings::default().with_k(2));
+    model.train();
+    let truth = vec![1_u8, 1, 2, 2];
+    model.evaluate(&truth);
+
+    // Act
+    let output = format!("{model}");
+
+    // Assert
     assert!(output.contains("1.00"));
 }
 


### PR DESCRIPTION
## Summary
- evaluate the minimal clustering example with the fixture's known labels so metrics render in the output table
- add a regression test that exercises evaluation using the CSV fixture leveraged by the example

## Testing
- cargo clippy --all-targets -- -D warnings -D clippy::pedantic
- cargo test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916690abb048325942b783804928010)