### PR TITLE
Add baseline cluster metrics to clustering summary table

### DIFF
--- a/tests/clustering.rs
+++ b/tests/clustering.rs
@@ -89,6 +89,8 @@ fn clustering_model_display_shows_metrics() {
     assert!(output.contains("KMeans"));
     assert!(output.contains("Agglomerative"));
     assert!(output.contains("DBSCAN"));
+    assert!(output.contains("Clusters"));
+    assert!(output.contains("Noise"));
     assert!(output.contains("V-Measure"));
     assert!(output.contains("1.00"));
 }
@@ -124,6 +126,23 @@ fn clustering_model_display_shows_configured_algorithm_when_untrained() {
     // Assert
     assert!(output.contains("DBSCAN (untrained)"));
     assert!(output.contains("Homogeneity"));
+}
+
+#[test]
+fn clustering_model_display_shows_baseline_without_ground_truth() {
+    // Arrange
+    let x = clustering_testing_data();
+    let mut model: ClusteringModel<f64, u8, DenseMatrix<f64>, Vec<u8>> =
+        ClusteringModel::new(x.clone(), ClusteringSettings::default().with_k(2));
+    model.train();
+
+    // Act
+    let output = format!("{model}");
+
+    // Assert
+    assert!(output.contains("Clusters"));
+    assert!(output.contains("Noise"));
+    assert!(output.contains('2'));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- compute baseline cluster counts and noise totals during training
- display baseline metrics alongside homogeneity/completeness/v-measure in the clustering summary
- add regression tests to ensure baseline information appears without ground-truth labels

## Testing
- cargo fmt
- cargo clippy --all-targets -- -D warnings -D clippy::pedantic
- cargo test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918c81c9f3083259dcecd04393f12bf)